### PR TITLE
Allu 85: check for anonymizable cable reports

### DIFF
--- a/backend/external-service/src/main/java/fi/hel/allu/external/controller/maintenance/ApplicationArchiveController.java
+++ b/backend/external-service/src/main/java/fi/hel/allu/external/controller/maintenance/ApplicationArchiveController.java
@@ -48,6 +48,7 @@ public class ApplicationArchiveController {
     @PatchMapping(value = "/checkanonymizable")
     @PreAuthorize("hasAnyRole('ROLE_SERVICE')")
     public ResponseEntity<Void> checkForAnonymizableApplications() {
+      applicationArchiverService.checkForAnonymizableApplications();
       return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/backend/external-service/src/main/java/fi/hel/allu/external/controller/maintenance/ApplicationArchiveController.java
+++ b/backend/external-service/src/main/java/fi/hel/allu/external/controller/maintenance/ApplicationArchiveController.java
@@ -45,4 +45,9 @@ public class ApplicationArchiveController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @PatchMapping(value = "/checkanonymizable")
+    @PreAuthorize("hasAnyRole('ROLE_SERVICE')")
+    public ResponseEntity<Void> checkForAnonymizableApplications() {
+      return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/backend/model-service/src/main/java/fi/hel/allu/model/controller/ApplicationController.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/controller/ApplicationController.java
@@ -412,6 +412,17 @@ public class ApplicationController {
     return new ResponseEntity<>(applicationService.findActiveExcavationAnnouncements(), HttpStatus.OK);
   }
 
+  @GetMapping(value = "/potentiallyanonymizable")
+  public ResponseEntity<List<Application>> findPotentiallyAnonymizableApplications() {
+    return new ResponseEntity<>(applicationService.findPotentiallyAnonymizableApplications(), HttpStatus.OK);
+  }
+
+  @PatchMapping(value = "/addtoanonymizable")
+  public ResponseEntity<List<Application>> addToAnonymizableApplications(@RequestBody List<Integer> applicationsIds) {
+    applicationService.addToAnonymizableApplications(applicationsIds);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
   /**
    * Finds finished notes
    */

--- a/backend/model-service/src/main/java/fi/hel/allu/model/dao/ApplicationDao.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/dao/ApplicationDao.java
@@ -9,6 +9,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.sql.SQLExpressions;
 import com.querydsl.sql.SQLQueryFactory;
 import com.querydsl.sql.dml.SQLInsertClause;
+import fi.hel.allu.QAnonymizableApplication;
 import fi.hel.allu.QApplication;
 import fi.hel.allu.common.domain.ApplicationDateReport;
 import fi.hel.allu.common.domain.ApplicationStatusInfo;
@@ -35,6 +36,7 @@ import static com.querydsl.core.group.GroupBy.groupBy;
 import static com.querydsl.core.group.GroupBy.list;
 import static com.querydsl.core.types.Projections.bean;
 import static com.querydsl.sql.SQLExpressions.select;
+import static fi.hel.allu.QAnonymizableApplication.anonymizableApplication;
 import static fi.hel.allu.QApplication.application;
 import static fi.hel.allu.QApplicationCustomer.applicationCustomer;
 import static fi.hel.allu.QApplicationCustomerContact.applicationCustomerContact;
@@ -186,6 +188,22 @@ public class ApplicationDao {
     BooleanExpression whereCondition = application.type.eq(ApplicationType.EXCAVATION_ANNOUNCEMENT);
     whereCondition = whereCondition.and(application.status.notIn(INACTIVE_EXCAVATION_ANNOUNCEMENT_STATUSES));
     return queryFactory.select(applicationBean).from(application).where(whereCondition).fetch();
+  }
+
+  @Transactional(readOnly = true)
+  public List<Application> fetchPotentiallyAnonymizableApplications() {
+    SubQueryExpression<Integer> alreadyFounds = select(anonymizableApplication.applicationId).from(anonymizableApplication);
+    BooleanExpression whereCondition = application.type.eq(ApplicationType.CABLE_REPORT);
+    whereCondition = whereCondition.and(application.endTime.before(ZonedDateTime.now().minusYears(2)));
+    whereCondition = whereCondition.and(application.id.notIn(alreadyFounds));
+    return queryFactory.select(applicationBean).from(application).where(whereCondition).fetch();
+  }
+
+  @Transactional
+  public void insertToAnonymizableApplication(List<Integer> applicationIds) {
+    SQLInsertClause insertQuery = queryFactory.insert(anonymizableApplication);
+    for (Integer applicationId : applicationIds) insertQuery.set(anonymizableApplication.applicationId, applicationId).addBatch();
+    insertQuery.execute();
   }
 
   @Transactional(readOnly = true)

--- a/backend/model-service/src/main/java/fi/hel/allu/model/service/ApplicationService.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/service/ApplicationService.java
@@ -429,6 +429,14 @@ public class ApplicationService {
     return applicationDao.findActiveExcavationAnnouncements();
   }
 
+  public List<Application> findPotentiallyAnonymizableApplications() {
+    return applicationDao.fetchPotentiallyAnonymizableApplications();
+  }
+
+  public void addToAnonymizableApplications(List<Integer> applicationsIds) {
+    applicationDao.insertToAnonymizableApplication(applicationsIds);
+  }
+
   @Transactional(readOnly = true)
   public List<Integer> findFinishedNotes() {
     return applicationDao.findFinishedNotes();

--- a/backend/model-service/src/test/java/fi/hel/allu/model/dao/ApplicationDaoTest.java
+++ b/backend/model-service/src/test/java/fi/hel/allu/model/dao/ApplicationDaoTest.java
@@ -1,5 +1,7 @@
 package fi.hel.allu.model.dao;
 
+import com.querydsl.sql.SQLQueryFactory;
+import fi.hel.allu.QAnonymizableApplication;
 import fi.hel.allu.common.domain.types.*;
 import fi.hel.allu.common.types.DistributionType;
 import fi.hel.allu.model.ModelApplication;
@@ -20,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import static fi.hel.allu.QAnonymizableApplication.anonymizableApplication;
 import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -36,6 +39,9 @@ public class ApplicationDaoTest {
   private ContactDao contactDao;
   @Autowired
   private DistributionEntryDao distributionEntryDao;
+
+  @Autowired
+  private SQLQueryFactory queryFactory;
 
   DistributionEntry testDistributionEntry;
 
@@ -396,6 +402,59 @@ public class ApplicationDaoTest {
       assertFalse(excludedStatuses.contains(app.getStatus()));
       assertEquals(ApplicationType.EXCAVATION_ANNOUNCEMENT, app.getType());
     }
+  }
+
+  @Test
+  public void testFetchPotentiallyAnonymizableApplications() {
+
+    // wrong types of applications
+    Application outdoor = testCommon.dummyOutdoorApplication("Outdoor application", "Outsider");
+    outdoor.setStatus(StatusType.HANDLING);
+    outdoor = applicationDao.insert(outdoor);
+
+    Application areaRental = testCommon.dummyAreaRentalApplication("Area rental", "Renter");
+    areaRental.setStatus(StatusType.DECISION);
+    areaRental = applicationDao.insert(areaRental);
+
+    // long enough ago and not already found - we want to get this one from the query
+    Application cableReport1 = testCommon.dummyCableReportApplication("Cable report1", "Reporter1");
+    cableReport1.setStatus(StatusType.DECISION);
+    cableReport1.setEndTime(ZonedDateTime.now().minusYears(2).minusMonths(6));
+    cableReport1 = applicationDao.insert(cableReport1);
+
+    // not long enough ago
+    Application cableReport2 = testCommon.dummyCableReportApplication("Cable report2", "Reporter2");
+    cableReport2.setStatus(StatusType.DECISION);
+    cableReport2.setEndTime(ZonedDateTime.now().minusYears(1).minusMonths(6));
+    cableReport2 = applicationDao.insert(cableReport2);
+
+    // long enough ago but already found
+    Application cableReport3 = testCommon.dummyCableReportApplication("Cable report3", "Reporter3");
+    cableReport3.setStatus(StatusType.DECISION);
+    cableReport3.setEndTime(ZonedDateTime.now().minusYears(2).minusMonths(6));
+    cableReport3 = applicationDao.insert(cableReport3);
+    applicationDao.insertToAnonymizableApplication(List.of(cableReport3.getId()));
+
+    List<Application> potentials = applicationDao.fetchPotentiallyAnonymizableApplications();
+
+    assertEquals(1, potentials.size());
+    assertEquals(potentials.get(0).getId(), cableReport1.getId());
+  }
+
+  @Test
+  public void testInsertToAnonymizableApplication() {
+    Integer app1 = testCommon.insertApplication("Outdoor1", "Customer1");
+    Integer app2 = testCommon.insertApplication("Outdoor2", "Customer2");
+    Integer app3 = testCommon.insertApplication("Outdoor3", "Customer3");
+
+    applicationDao.insertToAnonymizableApplication(List.of(app1, app2, app3));
+
+    List<Integer> applicationIds = queryFactory.select(anonymizableApplication.applicationId).from(anonymizableApplication).fetch();
+
+    assertEquals(3, applicationIds.size());
+    assert(applicationIds.contains(app1));
+    assert(applicationIds.contains(app2));
+    assert(applicationIds.contains(app3));
   }
 
   private ApplicationTag createApplicationTag(ApplicationTagType applicationTagType) {

--- a/backend/model-service/src/test/java/fi/hel/allu/model/testUtils/TestCommon.java
+++ b/backend/model-service/src/test/java/fi/hel/allu/model/testUtils/TestCommon.java
@@ -192,6 +192,14 @@ public class TestCommon {
     return app;
   }
 
+  public Application dummyCableReportApplication(String name, String owner) {
+    Application app = dummyBasicApplication(name, owner);
+    app.setType(ApplicationType.CABLE_REPORT);
+    app.setKindsWithSpecifiers(Collections.singletonMap(ApplicationKind.STREET_AND_GREEN, Collections.emptyList()));
+    app.setExtension(dummyCableReport());
+    return app;
+  }
+
   /**
    * Create a dummy outdoor applicationExtension.
    *
@@ -235,6 +243,11 @@ public class TestCommon {
     ExcavationAnnouncement excavationAnnouncement = new ExcavationAnnouncement();
     excavationAnnouncement.setAdditionalInfo("Some additional info");
     return excavationAnnouncement;
+  }
+
+  public ApplicationExtension dummyCableReport() {
+    CableReport cableReport = new CableReport();
+    return cableReport;
   }
 
   public ApplicationTag dummyTag(ApplicationTagType tagType) {

--- a/backend/scheduler-service/src/main/java/fi/hel/allu/scheduler/config/ApplicationProperties.java
+++ b/backend/scheduler-service/src/main/java/fi/hel/allu/scheduler/config/ApplicationProperties.java
@@ -395,6 +395,10 @@ public class ApplicationProperties {
     return getExtServiceUrl("/v1/applications/terminated/status");
   }
 
+  public String getCheckAnonymizableApplicationsUrl() {
+    return getExtServiceUrl("/v1/applications/checkanonymizable");
+  }
+
   public String getKnownHosts() {
     return knownHosts;
   }

--- a/backend/scheduler-service/src/main/java/fi/hel/allu/scheduler/controller/ScheduleRunner.java
+++ b/backend/scheduler-service/src/main/java/fi/hel/allu/scheduler/controller/ScheduleRunner.java
@@ -104,4 +104,9 @@ public class ScheduleRunner {
   public void updateCityDistricts() {
     cityDistrictUpdaterService.updateCityDistricts();
   }
+
+  @Scheduled(cron = "${anonymization.update.cronstring}")
+  public void checkAnonymizableApplications() {
+    applicationStatusUpdaterService.checkAnonymizableApplications();
+  }
 }

--- a/backend/scheduler-service/src/main/java/fi/hel/allu/scheduler/service/ApplicationStatusUpdaterService.java
+++ b/backend/scheduler-service/src/main/java/fi/hel/allu/scheduler/service/ApplicationStatusUpdaterService.java
@@ -56,4 +56,11 @@ public class ApplicationStatusUpdaterService {
         applicationProperties.getUpdateTerminatedApplicationsUrl(), HttpMethod.PATCH,
         new HttpEntity<>(null, authenticationService.createAuthenticationHeader()), Void.class).getBody();
   }
+
+  public void checkAnonymizableApplications() {
+    logger.info("Checking for anonymizable applications");
+    restTemplate.exchange(
+      applicationProperties.getCheckAnonymizableApplicationsUrl(), HttpMethod.PATCH,
+      new HttpEntity<>(null, authenticationService.createAuthenticationHeader()), Void.class).getBody();
+  }
 }

--- a/backend/scheduler-service/src/main/resources/application.properties
+++ b/backend/scheduler-service/src/main/resources/application.properties
@@ -77,3 +77,5 @@ invoice.notification.subject=Allu - uusia laskuja
 application.status.update.cronstring=0 1 * * * *
 
 cityDistricts.update.cronstring=30 0 * * * *
+
+anonymization.update.cronstring=0 */5 * * * *

--- a/backend/service-core/pom.xml
+++ b/backend/service-core/pom.xml
@@ -96,6 +96,10 @@
           <artifactId>jwks-rsa</artifactId>
           <version>0.21.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
         <!-- Mock web server dependencies -->
         <dependency>
           <groupId>com.squareup.okhttp3</groupId>

--- a/backend/service-core/src/main/java/fi/hel/allu/servicecore/config/ApplicationProperties.java
+++ b/backend/service-core/src/main/java/fi/hel/allu/servicecore/config/ApplicationProperties.java
@@ -1396,6 +1396,14 @@ public class ApplicationProperties {
     return getModelServiceUrl("/applications/activeexcavationannouncements");
   }
 
+  public String getFetchPotentiallyAnonymizableApplicationsUrl() {
+    return getModelServiceUrl("/applications/potentiallyanonymizable");
+  }
+
+  public String getAddToAnonymizableApplicationsUrl() {
+    return getModelServiceUrl("/applications/addtoanonymizable");
+  }
+
   /**
    * @return url to fetch finished notes
    */

--- a/backend/service-core/src/main/java/fi/hel/allu/servicecore/service/ApplicationArchiverService.java
+++ b/backend/service-core/src/main/java/fi/hel/allu/servicecore/service/ApplicationArchiverService.java
@@ -256,7 +256,7 @@ public class ApplicationArchiverService {
     return false;
   }
   public void checkForAnonymizableApplications() {
-    addToAnonymizableApplications(
+    List<Integer> anonymizeIds =
       fetchPotentiallyAnonymizableApplications().stream()
       // cable reports are all we know how to handle for now, let's be sure although DB should return only them currently
       .filter(app -> app.getType() == ApplicationType.CABLE_REPORT)
@@ -265,8 +265,9 @@ public class ApplicationArchiverService {
       .filter(app -> ((CableReport) app.getExtension()).getValidityTime().isBefore(ZonedDateTime.now().minusYears(2)))
       .filter(app -> !cableReportAssociatedWithActiveExcavationAnnouncement(app))
       .map(Application::getId)
-      .collect(Collectors.toList())
-    );
+      .toList();
+
+    if (anonymizeIds.size() > 0) addToAnonymizableApplications(anonymizeIds);
 
     // these might have been fetched in cableReportAssociatedWithActiveExcavationAnnouncement(), release them now
     activeExcavationAnnouncements = null;

--- a/backend/service-core/src/main/java/fi/hel/allu/servicecore/service/ApplicationService.java
+++ b/backend/service-core/src/main/java/fi/hel/allu/servicecore/service/ApplicationService.java
@@ -21,6 +21,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -57,6 +58,9 @@ public class ApplicationService {
       ApplicationEventDispatcher applicationEventDispatcher) {
     this.applicationProperties = applicationProperties;
     this.restTemplate = restTemplate;
+    // Needed for PATCH support
+    HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+    restTemplate.setRequestFactory(requestFactory);
     this.applicationMapper = applicationMapper;
     this.userService = userService;
     this.personAuditLogService = personAuditLogService;
@@ -393,6 +397,17 @@ public class ApplicationService {
     ParameterizedTypeReference<List<Application>> typeRef = new ParameterizedTypeReference<List<Application>>() {};
     return restTemplate.exchange(applicationProperties.getActiveExcavationAnnouncementsUrl(),
       HttpMethod.GET, null, typeRef).getBody();
+  }
+
+  public List<Application> fetchPotentiallyAnonymizableApplications() {
+    ParameterizedTypeReference<List<Application>> typeRef = new ParameterizedTypeReference<List<Application>>() {};
+    return restTemplate.exchange(applicationProperties.getFetchPotentiallyAnonymizableApplicationsUrl(),
+      HttpMethod.GET, null, typeRef).getBody();
+  }
+
+  public void addToAnonymizableApplications(List<Integer> applicationIds) {
+    restTemplate.exchange(applicationProperties.getAddToAnonymizableApplicationsUrl(),
+      HttpMethod.PATCH, new HttpEntity<>(applicationIds), Void.class);
   }
 
   public List<Integer> findFinishedNotes() {

--- a/backend/service-core/src/main/java/fi/hel/allu/servicecore/service/ApplicationServiceComposer.java
+++ b/backend/service-core/src/main/java/fi/hel/allu/servicecore/service/ApplicationServiceComposer.java
@@ -582,6 +582,14 @@ public class ApplicationServiceComposer {
     return applicationService.findActiveExcavationAnnouncements();
   }
 
+  public List<Application> fetchPotentiallyAnonymizableApplications() {
+    return List.of();
+  }
+
+  public void addToAnonymizableApplications(List<Integer> applicationIds) {
+
+  }
+
   public ApplicationStatusInfo getApplicationStatus(Integer applicationId) {
     return applicationService.getApplicationStatus(applicationId);
   }

--- a/backend/service-core/src/main/java/fi/hel/allu/servicecore/service/ApplicationServiceComposer.java
+++ b/backend/service-core/src/main/java/fi/hel/allu/servicecore/service/ApplicationServiceComposer.java
@@ -583,11 +583,11 @@ public class ApplicationServiceComposer {
   }
 
   public List<Application> fetchPotentiallyAnonymizableApplications() {
-    return List.of();
+    return applicationService.fetchPotentiallyAnonymizableApplications();
   }
 
   public void addToAnonymizableApplications(List<Integer> applicationIds) {
-
+    applicationService.addToAnonymizableApplications(applicationIds);
   }
 
   public ApplicationStatusInfo getApplicationStatus(Integer applicationId) {

--- a/backend/service-core/src/test/java/fi/hel/allu/servicecore/service/ApplicationArchiverServiceTest.java
+++ b/backend/service-core/src/test/java/fi/hel/allu/servicecore/service/ApplicationArchiverServiceTest.java
@@ -1,10 +1,12 @@
 package fi.hel.allu.servicecore.service;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 
 import fi.hel.allu.model.domain.Application;
+import fi.hel.allu.model.domain.CableReport;
 import fi.hel.allu.model.domain.ExcavationAnnouncement;
 import fi.hel.allu.servicecore.domain.*;
 import org.junit.Before;
@@ -238,6 +240,16 @@ public class ApplicationArchiverServiceTest {
       .changeStatus(eq(APPLICATION_ID), eq(StatusType.FINISHED));
   }
 
+  @Test
+  public void shouldAnonymizeSuitableCableReports() {
+    when(applicationServiceComposer.fetchPotentiallyAnonymizableApplications()).thenReturn(createAnonymizableCableReports());
+    when(applicationServiceComposer.fetchActiveExcavationAnnouncements()).thenReturn(createExcavationAnnouncementList());
+
+    archiverService.checkForAnonymizableApplications();
+
+    verify(applicationServiceComposer, times(1)).addToAnonymizableApplications(eq(List.of(1,3)));
+  }
+
   private void createApplication() {
     applicationJson = new ApplicationJson();
     applicationJson.setStatus(StatusType.FINISHED);
@@ -282,5 +294,49 @@ public class ApplicationArchiverServiceTest {
     excavationAnnouncement3.setExtension(extensionJson3);
 
     return List.of(excavationAnnouncement1, excavationAnnouncement2, excavationAnnouncement3);
+  }
+
+  private List<Application> createAnonymizableCableReports() {
+    Application cableReport1 = new Application();
+    cableReport1.setType(ApplicationType.CABLE_REPORT);
+    cableReport1.setId(1);
+    cableReport1.setApplicationId("JS240000001");
+    cableReport1.setStatus(StatusType.DECISION);
+    cableReport1.setEndTime(ZonedDateTime.now().minusYears(2).minusMonths(6));
+    CableReport extension1 = new CableReport();
+    extension1.setValidityTime(ZonedDateTime.now().minusYears(2).minusMonths(5));
+    cableReport1.setExtension(extension1);
+
+    Application cableReport2 = new Application();
+    cableReport2.setType(ApplicationType.CABLE_REPORT);
+    cableReport2.setId(2);
+    cableReport2.setApplicationId("JS240000002");
+    cableReport2.setStatus(StatusType.DECISION);
+    cableReport2.setEndTime(ZonedDateTime.now().minusYears(2).minusMonths(1));
+    CableReport extension2 = new CableReport();
+    extension2.setValidityTime(ZonedDateTime.now().minusYears(1).minusMonths(11));
+    cableReport2.setExtension(extension2);
+
+    Application cableReport3 = new Application();
+    cableReport3.setType(ApplicationType.CABLE_REPORT);
+    cableReport3.setId(3);
+    cableReport3.setApplicationId("JS240000003");
+    cableReport3.setStatus(StatusType.DECISION);
+    cableReport3.setEndTime(ZonedDateTime.now().minusYears(2).minusMonths(3));
+    CableReport extension3 = new CableReport();
+    extension3.setValidityTime(ZonedDateTime.now().minusYears(2).minusMonths(2));
+    cableReport3.setExtension(extension3);
+
+    Application cableReport4 = new Application();
+    cableReport4.setType(ApplicationType.CABLE_REPORT);
+    cableReport4.setId(4);
+    cableReport4.setApplicationId("JS2400701");
+    cableReport4.setStatus(StatusType.DECISION);
+    cableReport4.setEndTime(ZonedDateTime.now().minusYears(2).minusMonths(5));
+    CableReport extension4 = new CableReport();
+    extension4.setValidityTime(ZonedDateTime.now().minusYears(2).minusMonths(3));
+    cableReport4.setExtension(extension4);
+
+    return List.of(cableReport1, cableReport2, cableReport3, cableReport4);
   }
 }


### PR DESCRIPTION
Add a scheduled check for potential anonymizable cable report applications. Adds the IDs of the anonymizable applications to the anonymizable_application table in the database.