### PR TITLE
ALLU-86: filtteröidään Elasticsearchissa pois hakemukset joiden status on ANONYMIZED

### DIFF
--- a/backend/model-service/src/main/java/fi/hel/allu/model/dao/ApplicationDao.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/dao/ApplicationDao.java
@@ -24,6 +24,7 @@ import fi.hel.allu.model.querydsl.ExcludingMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -131,8 +132,14 @@ public class ApplicationDao {
   public Page<Application> findAll(Pageable pageRequest) {
     long offset = (pageRequest == null) ? 0 : pageRequest.getOffset();
     int count = (pageRequest == null) ? 100 : pageRequest.getPageSize();
-    QueryResults<Application> queryResults = queryFactory.select(applicationBean).from(application)
-        .orderBy(application.id.asc()).offset(offset).limit(count).fetchResults();
+    QueryResults<Application> queryResults = queryFactory
+      .select(applicationBean)
+      .from(application)
+      .where(application.status.ne(StatusType.ANONYMIZED))
+      .orderBy(application.id.asc())
+      .offset(offset)
+      .limit(count)
+      .fetchResults();
     return new PageImpl<>(populateDependencies(queryResults.getResults()), pageRequest, queryResults.getTotal());
   }
 


### PR DESCRIPTION
ApplicationDao.java sisältää muutoksen kyselyyn, jossa haetaan kaikki hakemukset sivutusoptiolla. Kyselyssä karsitaan pois hakemukset, joiden status on "ANONYMIZED". ApplicationDaoSpec.java sisältää uuden testin, jossa tarkastetaan ettei hakutulokset sisällä kyseisellä statuksella olevia hakemuksia.