### PR TITLE
ALLU-185: Performance improvements for handling `POST /v1/supervisiontasks/search` requests

### DIFF
--- a/backend/model-domain/src/main/java/fi/hel/allu/model/domain/SupervisionWorkItem.java
+++ b/backend/model-domain/src/main/java/fi/hel/allu/model/domain/SupervisionWorkItem.java
@@ -1,6 +1,8 @@
 package fi.hel.allu.model.domain;
 
+import fi.hel.allu.common.domain.types.ApplicationType;
 import fi.hel.allu.common.domain.types.StatusType;
+import fi.hel.allu.common.domain.types.SupervisionTaskStatusType;
 import fi.hel.allu.common.domain.types.SupervisionTaskType;
 
 import java.time.ZonedDateTime;
@@ -11,8 +13,18 @@ public class SupervisionWorkItem {
   private Integer applicationId;
   private String applicationIdText;
   private StatusType applicationStatus;
+  private ApplicationType applicationType;
   private Integer creatorId;
+  private ZonedDateTime creationTime;
   private ZonedDateTime plannedFinishingTime;
+  private ZonedDateTime actualFinishingTime;
+  private SupervisionTaskStatusType taskStatus;
+  private String description;
+  private String result;
+  private Integer locationId;
+  private Integer locationKey;
+  private String ownerRealName;
+  private String ownerUserName;
   private String[] address;
   private String projectName;
   private Integer ownerId;
@@ -95,5 +107,85 @@ public class SupervisionWorkItem {
 
   public void setOwnerId(Integer ownerId) {
     this.ownerId = ownerId;
+  }
+
+  public ApplicationType getApplicationType() {
+    return applicationType;
+  }
+
+  public void setApplicationType(ApplicationType applicationType) {
+    this.applicationType = applicationType;
+  }
+
+  public ZonedDateTime getCreationTime() {
+    return creationTime;
+  }
+
+  public void setCreationTime(ZonedDateTime creationTime) {
+    this.creationTime = creationTime;
+  }
+
+  public ZonedDateTime getActualFinishingTime() {
+    return actualFinishingTime;
+  }
+
+  public void setActualFinishingTime(ZonedDateTime actualFinishingTime) {
+    this.actualFinishingTime = actualFinishingTime;
+  }
+
+  public SupervisionTaskStatusType getTaskStatus() {
+    return taskStatus;
+  }
+
+  public void setTaskStatus(SupervisionTaskStatusType taskStatus) {
+    this.taskStatus = taskStatus;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getResult() {
+    return result;
+  }
+
+  public void setResult(String result) {
+    this.result = result;
+  }
+
+  public Integer getLocationId() {
+    return locationId;
+  }
+
+  public void setLocationId(Integer locationId) {
+    this.locationId = locationId;
+  }
+
+  public Integer getLocationKey() {
+    return locationKey;
+  }
+
+  public void setLocationKey(Integer locationKey) {
+    this.locationKey = locationKey;
+  }
+
+  public String getOwnerRealName() {
+    return ownerRealName;
+  }
+
+  public void setOwnerRealName(String ownerRealName) {
+    this.ownerRealName = ownerRealName;
+  }
+
+  public String getOwnerUserName() {
+    return ownerUserName;
+  }
+
+  public void setOwnerUserName(String ownerUserName) {
+    this.ownerUserName = ownerUserName;
   }
 }

--- a/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
@@ -1,14 +1,16 @@
 package fi.hel.allu.model.dao;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.QBean;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.sql.SQLExpressions;
 import com.querydsl.sql.SQLQuery;
 import com.querydsl.sql.SQLQueryFactory;
@@ -179,9 +181,42 @@ public class SupervisionTaskDao {
       supervisionTask.type.eq(SupervisionTaskType.FINAL_SUPERVISION));
   }
 
+  /**
+   * Abstracts over column paths shared between the supervision_task base table
+   * and the supervision_task_with_address view, so that condition-building logic
+   * can be reused for both the data query (against the view) and the lightweight
+   * count query (against the base table).
+   */
+  private interface TaskPaths {
+    EnumPath<SupervisionTaskStatusType> status();
+    EnumPath<SupervisionTaskType> type();
+    DateTimePath<ZonedDateTime> plannedFinishingTime();
+    NumberPath<Integer> ownerId();
+    NumberPath<Integer> applicationId();
+    NumberPath<Integer> locationId();
+  }
+
+  private static final TaskPaths VIEW_PATHS = new TaskPaths() {
+    @Override public EnumPath<SupervisionTaskStatusType> status() { return supervisionTaskWithAddress.status; }
+    @Override public EnumPath<SupervisionTaskType> type() { return supervisionTaskWithAddress.type; }
+    @Override public DateTimePath<ZonedDateTime> plannedFinishingTime() { return supervisionTaskWithAddress.plannedFinishingTime; }
+    @Override public NumberPath<Integer> ownerId() { return supervisionTaskWithAddress.ownerId; }
+    @Override public NumberPath<Integer> applicationId() { return supervisionTaskWithAddress.applicationId; }
+    @Override public NumberPath<Integer> locationId() { return supervisionTaskWithAddress.locationId; }
+  };
+
+  private static final TaskPaths BASE_TABLE_PATHS = new TaskPaths() {
+    @Override public EnumPath<SupervisionTaskStatusType> status() { return supervisionTask.status; }
+    @Override public EnumPath<SupervisionTaskType> type() { return supervisionTask.type; }
+    @Override public DateTimePath<ZonedDateTime> plannedFinishingTime() { return supervisionTask.plannedFinishingTime; }
+    @Override public NumberPath<Integer> ownerId() { return supervisionTask.ownerId; }
+    @Override public NumberPath<Integer> applicationId() { return supervisionTask.applicationId; }
+    @Override public NumberPath<Integer> locationId() { return supervisionTask.locationId; }
+  };
+
   @Transactional
   public Page<SupervisionWorkItem> search(SupervisionTaskSearchCriteria searchCriteria, Pageable pageRequest) {
-    BooleanExpression conditions = conditions(searchCriteria)
+    BooleanExpression dataConditions = conditions(searchCriteria, VIEW_PATHS)
       .reduce((left, right) -> left.and(right))
       .orElse(Expressions.TRUE);
 
@@ -200,12 +235,43 @@ public class SupervisionTaskDao {
       .leftJoin(applStatusStructure).on(applStatusStructure.typeName.eq("StatusType"))
       .leftJoin(applStatusAttribute).on(applStatusAttribute.structureMetaId.eq(applStatusStructure.id)
         .and(applStatusAttribute.name.eq(application.status.stringValue())))
-      .where(conditions);
+      .where(dataConditions);
 
     q = handlePageRequest(q, pageRequest);
 
-    QueryResults<SupervisionWorkItem> results = q.fetchResults();
-    return new PageImpl<>(results.getResults(), pageRequest, results.getTotal());
+    List<SupervisionWorkItem> results = q.fetch();
+    long total = countSupervisionTasks(searchCriteria);
+    return new PageImpl<>(results, pageRequest, total);
+  }
+
+  /**
+   * Lightweight count query against the base supervision_task table.
+   * Avoids the view, address resolution, project/user/metadata joins.
+   * Only joins application when the search criteria reference application fields.
+   */
+  private long countSupervisionTasks(SupervisionTaskSearchCriteria searchCriteria) {
+    BooleanExpression countConditions = conditions(searchCriteria, BASE_TABLE_PATHS)
+      .reduce((left, right) -> left.and(right))
+      .orElse(Expressions.TRUE);
+
+    SQLQuery<Long> countQuery = queryFactory.select(supervisionTask.id.count())
+      .from(supervisionTask);
+
+    if (needsApplicationJoin(searchCriteria)) {
+      countQuery = countQuery.leftJoin(application).on(supervisionTask.applicationId.eq(application.id));
+    }
+
+    return countQuery.where(countConditions).fetchOne();
+  }
+
+  /**
+   * Returns true if the search criteria contain any conditions that reference
+   * the application table (applicationId text prefix, applicationTypes, applicationStatus).
+   */
+  private static boolean needsApplicationJoin(SupervisionTaskSearchCriteria searchCriteria) {
+    return searchCriteria.getApplicationId() != null
+      || (searchCriteria.getApplicationTypes() != null && !searchCriteria.getApplicationTypes().isEmpty())
+      || (searchCriteria.getApplicationStatus() != null && !searchCriteria.getApplicationStatus().isEmpty());
   }
 
   /*
@@ -241,23 +307,23 @@ public class SupervisionTaskDao {
     return order.toArray(new OrderSpecifier<?>[order.size()]);
   }
 
-  private Stream<BooleanExpression> conditions(SupervisionTaskSearchCriteria searchCriteria) {
+  private Stream<BooleanExpression> conditions(SupervisionTaskSearchCriteria searchCriteria, TaskPaths paths) {
     List<SupervisionTaskStatusType> statuses = searchCriteria.getStatuses() != null && !searchCriteria.getStatuses().isEmpty() ?
       searchCriteria.getStatuses() : Collections.singletonList(SupervisionTaskStatusType.OPEN);
 
 
     return Stream.of(
-        Optional.of(supervisionTaskWithAddress.status.in(statuses)),
-        values(searchCriteria.getTaskTypes()).map(supervisionTaskWithAddress.type::in),
-        Optional.ofNullable(searchCriteria.getAfter()).map(supervisionTaskWithAddress.plannedFinishingTime::goe),
-        Optional.ofNullable(searchCriteria.getBefore()).map(supervisionTaskWithAddress.plannedFinishingTime::lt),
+        Optional.of(paths.status().in(statuses)),
+        values(searchCriteria.getTaskTypes()).map(paths.type()::in),
+        Optional.ofNullable(searchCriteria.getAfter()).map(paths.plannedFinishingTime()::goe),
+        Optional.ofNullable(searchCriteria.getBefore()).map(paths.plannedFinishingTime()::lt),
         Optional.ofNullable(searchCriteria.getApplicationId()).map(String::toUpperCase).map(application.applicationId::startsWith),
-        values(searchCriteria.getOwners()).map(supervisionTaskWithAddress.ownerId::in),
+        values(searchCriteria.getOwners()).map(paths.ownerId()::in),
         values(searchCriteria.getApplicationTypes()).map(application.type::in),
         values(searchCriteria.getApplicationStatus()).map(application.status::in),
-        values(searchCriteria.getCityDistrictIds()).map(this::cityDistrictsIn),
+        values(searchCriteria.getCityDistrictIds()).map(ids -> cityDistrictsIn(ids, paths)),
         // Include also empty application ID list in search conditions
-        Optional.ofNullable(searchCriteria.getApplicationIds()).map(supervisionTaskWithAddress.applicationId::in)
+        Optional.ofNullable(searchCriteria.getApplicationIds()).map(paths.applicationId()::in)
       ).filter(opt -> opt.isPresent())
       .map(opt -> opt.get());
   }
@@ -267,7 +333,7 @@ public class SupervisionTaskDao {
       .filter(values -> !values.isEmpty());
   }
 
-  private BooleanExpression cityDistrictsIn(List<Integer> ids) {
+  private BooleanExpression cityDistrictsIn(List<Integer> ids, TaskPaths paths) {
     // Use city district override when it is defined
     BooleanExpression override = location.cityDistrictIdOverride.isNotNull().and(location.cityDistrictIdOverride.in(ids));
     BooleanExpression calculated = location.cityDistrictIdOverride.isNull().and(location.cityDistrictId.in(ids));
@@ -277,11 +343,11 @@ public class SupervisionTaskDao {
     return SQLExpressions.selectOne()
       .from(location)
       .where(
-        supervisionTaskWithAddress.locationId.isNotNull()
-          .and(supervisionTaskWithAddress.locationId.eq(location.id)
+        paths.locationId().isNotNull()
+          .and(paths.locationId().eq(location.id)
             .and(effective))
-          .or(supervisionTaskWithAddress.locationId.isNull()
-            .and(supervisionTaskWithAddress.applicationId.eq(location.applicationId)
+          .or(paths.locationId().isNull()
+            .and(paths.applicationId().eq(location.applicationId)
               .and(effective))))
       .exists();
   }

--- a/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
@@ -15,6 +15,7 @@ import com.querydsl.sql.SQLExpressions;
 import com.querydsl.sql.SQLQuery;
 import com.querydsl.sql.SQLQueryFactory;
 import fi.hel.allu.QApplication;
+import fi.hel.allu.QLocation;
 import fi.hel.allu.QAttributeMeta;
 import fi.hel.allu.QStructureMeta;
 import fi.hel.allu.QUser;
@@ -248,7 +249,8 @@ public class SupervisionTaskDao {
       .leftJoin(application).on(supervisionTaskWithAddress.applicationId.eq(application.id))
       .leftJoin(project).on(application.projectId.eq(project.id))
       .leftJoin(creator).on(supervisionTaskWithAddress.creatorId.eq(creator.id))
-      .leftJoin(owner).on(supervisionTaskWithAddress.ownerId.eq(owner.id));
+      .leftJoin(owner).on(supervisionTaskWithAddress.ownerId.eq(owner.id))
+      .leftJoin(location).on(supervisionTaskWithAddress.locationId.eq(location.id));
 
     if (needsEnumSortJoins(pageRequest)) {
       q = q
@@ -362,20 +364,25 @@ public class SupervisionTaskDao {
   }
 
   private BooleanExpression cityDistrictsIn(List<Integer> ids, TaskPaths paths) {
+    // Dedicated QLocation instance so the EXISTS subquery is self-contained
+    // and does not collide with the outer query's LEFT JOIN on the static
+    // QLocation.location singleton.
+    QLocation loc = new QLocation("location");
+
     // Use city district override when it is defined
-    BooleanExpression override = location.cityDistrictIdOverride.isNotNull().and(location.cityDistrictIdOverride.in(ids));
-    BooleanExpression calculated = location.cityDistrictIdOverride.isNull().and(location.cityDistrictId.in(ids));
+    BooleanExpression override = loc.cityDistrictIdOverride.isNotNull().and(loc.cityDistrictIdOverride.in(ids));
+    BooleanExpression calculated = loc.cityDistrictIdOverride.isNull().and(loc.cityDistrictId.in(ids));
     BooleanExpression effective = override.or(calculated);
 
     // Use tasks location when available otherwise use supervision tasks application's locations
     return SQLExpressions.selectOne()
-      .from(location)
+      .from(loc)
       .where(
         paths.locationId().isNotNull()
-          .and(paths.locationId().eq(location.id)
+          .and(paths.locationId().eq(loc.id)
             .and(effective))
           .or(paths.locationId().isNull()
-            .and(paths.applicationId().eq(location.applicationId)
+            .and(paths.applicationId().eq(loc.applicationId)
               .and(effective))))
       .exists();
   }
@@ -402,8 +409,18 @@ public class SupervisionTaskDao {
     map.put("applicationId", application.id);
     map.put("applicationIdText", application.applicationId);
     map.put("applicationStatus", application.status);
+    map.put("applicationType", application.type);
     map.put("creatorId", supervisionTaskWithAddress.creatorId);
+    map.put("creationTime", supervisionTaskWithAddress.creationTime);
     map.put("plannedFinishingTime", supervisionTaskWithAddress.plannedFinishingTime);
+    map.put("actualFinishingTime", supervisionTaskWithAddress.actualFinishingTime);
+    map.put("taskStatus", supervisionTaskWithAddress.status);
+    map.put("description", supervisionTaskWithAddress.description);
+    map.put("result", supervisionTaskWithAddress.result);
+    map.put("locationId", supervisionTaskWithAddress.locationId);
+    map.put("locationKey", location.locationKey);
+    map.put("ownerRealName", owner.realName);
+    map.put("ownerUserName", owner.userName);
     map.put("address", supervisionTaskWithAddress.address);
     map.put("projectName", project.name);
     map.put("ownerId", supervisionTaskWithAddress.ownerId);

--- a/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
@@ -238,7 +238,7 @@ public class SupervisionTaskDao {
     return false;
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   public Page<SupervisionWorkItem> search(SupervisionTaskSearchCriteria searchCriteria, Pageable pageRequest) {
     BooleanExpression dataConditions = conditions(searchCriteria, VIEW_PATHS)
       .reduce((left, right) -> left.and(right))

--- a/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
@@ -214,6 +214,29 @@ public class SupervisionTaskDao {
     @Override public NumberPath<Integer> locationId() { return supervisionTask.locationId; }
   };
 
+  /**
+   * Sort keys that require the structure_meta/attribute_meta joins for enum
+   * column ordering (Finnish UI names instead of raw enum values).
+   */
+  private static final Set<String> ENUM_SORT_KEYS = Set.of(
+    "type", "application.type", "application.status");
+
+  /**
+   * Returns true if the page request sorts by any enum column that requires
+   * the structure_meta/attribute_meta joins.
+   */
+  private static boolean needsEnumSortJoins(Pageable pageRequest) {
+    if (pageRequest == null) {
+      return false;
+    }
+    for (Sort.Order order : pageRequest.getSort()) {
+      if (ENUM_SORT_KEYS.contains(order.getProperty())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Transactional
   public Page<SupervisionWorkItem> search(SupervisionTaskSearchCriteria searchCriteria, Pageable pageRequest) {
     BooleanExpression dataConditions = conditions(searchCriteria, VIEW_PATHS)
@@ -225,17 +248,22 @@ public class SupervisionTaskDao {
       .leftJoin(application).on(supervisionTaskWithAddress.applicationId.eq(application.id))
       .leftJoin(project).on(application.projectId.eq(project.id))
       .leftJoin(creator).on(supervisionTaskWithAddress.creatorId.eq(creator.id))
-      .leftJoin(owner).on(supervisionTaskWithAddress.ownerId.eq(owner.id))
-      .leftJoin(typeStructure).on(typeStructure.typeName.eq("SupervisionTaskType"))
-      .leftJoin(typeAttribute).on(typeAttribute.structureMetaId.eq(typeStructure.id)
-        .and(typeAttribute.name.eq(supervisionTaskWithAddress.type.stringValue())))
-      .leftJoin(applTypeStructure).on(applTypeStructure.typeName.eq("ApplicationType"))
-      .leftJoin(applTypeAttribute).on(applTypeAttribute.structureMetaId.eq(applTypeStructure.id)
-        .and(applTypeAttribute.name.eq(application.type.stringValue())))
-      .leftJoin(applStatusStructure).on(applStatusStructure.typeName.eq("StatusType"))
-      .leftJoin(applStatusAttribute).on(applStatusAttribute.structureMetaId.eq(applStatusStructure.id)
-        .and(applStatusAttribute.name.eq(application.status.stringValue())))
-      .where(dataConditions);
+      .leftJoin(owner).on(supervisionTaskWithAddress.ownerId.eq(owner.id));
+
+    if (needsEnumSortJoins(pageRequest)) {
+      q = q
+        .leftJoin(typeStructure).on(typeStructure.typeName.eq("SupervisionTaskType"))
+        .leftJoin(typeAttribute).on(typeAttribute.structureMetaId.eq(typeStructure.id)
+          .and(typeAttribute.name.eq(supervisionTaskWithAddress.type.stringValue())))
+        .leftJoin(applTypeStructure).on(applTypeStructure.typeName.eq("ApplicationType"))
+        .leftJoin(applTypeAttribute).on(applTypeAttribute.structureMetaId.eq(applTypeStructure.id)
+          .and(applTypeAttribute.name.eq(application.type.stringValue())))
+        .leftJoin(applStatusStructure).on(applStatusStructure.typeName.eq("StatusType"))
+        .leftJoin(applStatusAttribute).on(applStatusAttribute.structureMetaId.eq(applStatusStructure.id)
+          .and(applStatusAttribute.name.eq(application.status.stringValue())));
+    }
+
+    q = q.where(dataConditions);
 
     q = handlePageRequest(q, pageRequest);
 

--- a/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/dao/SupervisionTaskDao.java
@@ -6,11 +6,13 @@ import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.QBean;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseForEqBuilder;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.sql.SQLExpressions;
 import com.querydsl.sql.SQLQuery;
 import com.querydsl.sql.SQLQueryFactory;
@@ -29,12 +31,17 @@ import fi.hel.allu.model.domain.SupervisionTaskLocation;
 import fi.hel.allu.model.domain.SupervisionWorkItem;
 import fi.hel.allu.model.querydsl.ExcludingMapper;
 import org.geolatte.geom.Geometry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.annotation.PostConstruct;
 
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -63,26 +70,96 @@ public class SupervisionTaskDao {
   public static final List<Path<?>> UPDATE_READ_ONLY_FIELDS = Arrays.asList(
     supervisionTask.id, supervisionTask.creationTime, supervisionTask.type);
 
-  final static QStructureMeta typeStructure = new QStructureMeta("typeStructure");
-  final static QAttributeMeta typeAttribute = new QAttributeMeta("typeAttribute");
-  final static QStructureMeta applTypeStructure = new QStructureMeta("applTypeStructure");
-  final static QAttributeMeta applTypeAttribute = new QAttributeMeta("applTypeAttribute");
-  final static QStructureMeta applStatusStructure = new QStructureMeta("applStatusStructure");
-  final static QAttributeMeta applStatusAttribute = new QAttributeMeta("applStatusAttribute");
+  final static QStructureMeta structureMeta = QStructureMeta.structureMeta;
+  final static QAttributeMeta attributeMeta = QAttributeMeta.attributeMeta;
   final static QUser creator = new QUser("creator");
   final static QUser owner = new QUser("owner");
 
-  final static Map<String, Path<?>> COLUMNS = orderByColumns();
+  // Sort key constants for enum columns – used in both initEnumSortExpressions() and orderByColumns()
+  private static final String SORT_KEY_TASK_TYPE =
+      supervisionTask.type.getMetadata().getName();
+  private static final String SORT_KEY_APPLICATION_TYPE =
+      PathUtil.pathNameWithParent(application.type);
+  private static final String SORT_KEY_APPLICATION_STATUS =
+      PathUtil.pathNameWithParent(application.status);
+
+  private static final Logger logger = LoggerFactory.getLogger(SupervisionTaskDao.class);
 
   final QBean<SupervisionTask> supervisionTaskBean = bean(SupervisionTask.class, supervisionTask.all());
   final QBean<SupervisionWorkItem> supervisionWorkItemBean = bean(SupervisionWorkItem.class, supervisionWorkItemFields());
   final QBean<SupervisionTaskLocation> supervisionTaskLocationBean = bean(SupervisionTaskLocation.class, supervisionTaskLocation.all());
 
+  private Map<String, ComparableExpressionBase<?>> sortColumns;
 
   private final SQLQueryFactory queryFactory;
+  private final TransactionTemplate transactionTemplate;
 
-  public SupervisionTaskDao(SQLQueryFactory queryFactory) {
+  public SupervisionTaskDao(SQLQueryFactory queryFactory, TransactionTemplate transactionTemplate) {
     this.queryFactory = queryFactory;
+    this.transactionTemplate = transactionTemplate;
+  }
+
+  /**
+   * Loads enum-to-Finnish-UI-name translations from structure_meta/attribute_meta
+   * and builds CASE WHEN expressions for sorting enum columns by Finnish names.
+   * This replaces the 6 LEFT JOINs that were previously added to each search query.
+   */
+  @PostConstruct
+  void initEnumSortExpressions() {
+    transactionTemplate.executeWithoutResult(status -> {
+      // Load all translations: typeName -> (enumValue -> uiName)
+      Map<String, Map<String, String>> translations = queryFactory
+        .select(structureMeta.typeName, attributeMeta.name, attributeMeta.uiName)
+        .from(attributeMeta)
+        .join(structureMeta).on(attributeMeta.structureMetaId.eq(structureMeta.id))
+        .where(structureMeta.typeName.in("SupervisionTaskType", "ApplicationType", "StatusType"))
+        .fetch()
+        .stream()
+        .collect(Collectors.groupingBy(
+          tuple -> tuple.get(structureMeta.typeName),
+          Collectors.toMap(
+            tuple -> tuple.get(attributeMeta.name),
+            tuple -> tuple.get(attributeMeta.uiName)
+          )
+        ));
+
+      logger.info("Loaded enum sort translations: {} types, {} total mappings",
+        translations.size(),
+        translations.values().stream().mapToInt(Map::size).sum());
+
+      // Build CASE WHEN expressions for each enum column, keyed by their sort key constant
+      Map<String, StringExpression> enumSortExprs = Map.of(
+        SORT_KEY_TASK_TYPE, buildCaseExpression(
+          supervisionTaskWithAddress.type.stringValue(), translations.getOrDefault("SupervisionTaskType", Collections.emptyMap())),
+        SORT_KEY_APPLICATION_TYPE, buildCaseExpression(
+          application.type.stringValue(), translations.getOrDefault("ApplicationType", Collections.emptyMap())),
+        SORT_KEY_APPLICATION_STATUS, buildCaseExpression(
+          application.status.stringValue(), translations.getOrDefault("StatusType", Collections.emptyMap()))
+      );
+
+      // Build sortColumns map with CASE expressions instead of attribute_meta.ui_name paths
+      sortColumns = orderByColumns(enumSortExprs);
+    });
+  }
+
+  /**
+   * Builds a CASE column WHEN 'ENUM_VALUE' THEN 'Finnish Name' ... END expression
+   * for use as a sort key.
+   */
+  private static StringExpression buildCaseExpression(
+      StringExpression column, Map<String, String> enumToUiName) {
+    if (enumToUiName.isEmpty()) {
+      return column; // fallback: sort by raw enum value
+    }
+    Iterator<Map.Entry<String, String>> it = enumToUiName.entrySet().iterator();
+    Map.Entry<String, String> first = it.next();
+    CaseForEqBuilder<String>.Cases<String, StringExpression> cases =
+      column.when(first.getKey()).then(first.getValue());
+    while (it.hasNext()) {
+      Map.Entry<String, String> entry = it.next();
+      cases = cases.when(entry.getKey()).then(entry.getValue());
+    }
+    return cases.otherwise(column);
   }
 
   @Transactional(readOnly = true)
@@ -215,29 +292,6 @@ public class SupervisionTaskDao {
     @Override public NumberPath<Integer> locationId() { return supervisionTask.locationId; }
   };
 
-  /**
-   * Sort keys that require the structure_meta/attribute_meta joins for enum
-   * column ordering (Finnish UI names instead of raw enum values).
-   */
-  private static final Set<String> ENUM_SORT_KEYS = Set.of(
-    "type", "application.type", "application.status");
-
-  /**
-   * Returns true if the page request sorts by any enum column that requires
-   * the structure_meta/attribute_meta joins.
-   */
-  private static boolean needsEnumSortJoins(Pageable pageRequest) {
-    if (pageRequest == null) {
-      return false;
-    }
-    for (Sort.Order order : pageRequest.getSort()) {
-      if (ENUM_SORT_KEYS.contains(order.getProperty())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   @Transactional(readOnly = true)
   public Page<SupervisionWorkItem> search(SupervisionTaskSearchCriteria searchCriteria, Pageable pageRequest) {
     BooleanExpression dataConditions = conditions(searchCriteria, VIEW_PATHS)
@@ -250,22 +304,8 @@ public class SupervisionTaskDao {
       .leftJoin(project).on(application.projectId.eq(project.id))
       .leftJoin(creator).on(supervisionTaskWithAddress.creatorId.eq(creator.id))
       .leftJoin(owner).on(supervisionTaskWithAddress.ownerId.eq(owner.id))
-      .leftJoin(location).on(supervisionTaskWithAddress.locationId.eq(location.id));
-
-    if (needsEnumSortJoins(pageRequest)) {
-      q = q
-        .leftJoin(typeStructure).on(typeStructure.typeName.eq("SupervisionTaskType"))
-        .leftJoin(typeAttribute).on(typeAttribute.structureMetaId.eq(typeStructure.id)
-          .and(typeAttribute.name.eq(supervisionTaskWithAddress.type.stringValue())))
-        .leftJoin(applTypeStructure).on(applTypeStructure.typeName.eq("ApplicationType"))
-        .leftJoin(applTypeAttribute).on(applTypeAttribute.structureMetaId.eq(applTypeStructure.id)
-          .and(applTypeAttribute.name.eq(application.type.stringValue())))
-        .leftJoin(applStatusStructure).on(applStatusStructure.typeName.eq("StatusType"))
-        .leftJoin(applStatusAttribute).on(applStatusAttribute.structureMetaId.eq(applStatusStructure.id)
-          .and(applStatusAttribute.name.eq(application.status.stringValue())));
-    }
-
-    q = q.where(dataConditions);
+      .leftJoin(location).on(supervisionTaskWithAddress.locationId.eq(location.id))
+      .where(dataConditions);
 
     q = handlePageRequest(q, pageRequest);
 
@@ -327,10 +367,10 @@ public class SupervisionTaskDao {
    * @param sort
    * @return
    */
-  public static OrderSpecifier<?>[] toOrder(Sort sort) {
+  public OrderSpecifier<?>[] toOrder(Sort sort) {
     List<OrderSpecifier<?>> order = new ArrayList<>();
     sort.forEach(o -> {
-      ComparableExpressionBase<?> path = (ComparableExpressionBase<?>) Optional.ofNullable(COLUMNS.get(o.getProperty()))
+      ComparableExpressionBase<?> path = Optional.ofNullable(sortColumns.get(o.getProperty()))
         .orElseThrow(() -> new NoSuchEntityException("Bad sort key: " + o.getProperty()));
       order.add(o.isDescending() ? path.desc() : path.asc());
     });
@@ -387,14 +427,18 @@ public class SupervisionTaskDao {
       .exists();
   }
 
-  private static Map<String, Path<?>> orderByColumns() {
-    Map<String, Path<?>> cols = supervisionTaskWithAddress.getColumns().stream()
-      .collect(Collectors.toMap(c -> c.getMetadata().getName(), c -> c));
+  private static Map<String, ComparableExpressionBase<?>> orderByColumns(
+      Map<String, StringExpression> enumSortExprs) {
+    Map<String, ComparableExpressionBase<?>> cols = new HashMap<>();
+    // Add view columns that are ComparableExpressionBase (skip SimplePath columns like arrays)
+    supervisionTaskWithAddress.getColumns().forEach(c -> {
+      if (c instanceof ComparableExpressionBase) {
+        cols.put(c.getMetadata().getName(), (ComparableExpressionBase<?>) c);
+      }
+    });
 
-    // Override sorting for enum-column supervisionTask.type:
-    cols.put(supervisionTask.type.getMetadata().getName(), typeAttribute.uiName);
-    cols.put(PathUtil.pathNameWithParent(application.type), applTypeAttribute.uiName);
-    cols.put(PathUtil.pathNameWithParent(application.status), applStatusAttribute.uiName);
+    // Override sorting for enum columns: use CASE WHEN expressions with Finnish UI names
+    cols.putAll(enumSortExprs);
     cols.put(PathUtil.pathNameWithParent(application.applicationId), application.applicationId);
     cols.put(PathUtil.pathNameWithParent(project.name), project.name);
     cols.put(PathUtil.pathNameWithParent(creator.realName), creator.realName);

--- a/backend/model-service/src/main/resources/db/migration/V196__supervision_task_performance.sql
+++ b/backend/model-service/src/main/resources/db/migration/V196__supervision_task_performance.sql
@@ -1,0 +1,35 @@
+-- Change UNION to UNION ALL in supervision_task_with_address view.
+-- The two branches are mutually exclusive:
+--   branch 1: location_id IS NOT NULL (required by INNER JOIN)
+--   branch 2: location_id IS NULL (explicit WHERE clause)
+-- A single row cannot satisfy both conditions, so UNION deduplication is a no-op.
+-- Replacing it with UNION ALL eliminates the full sort/hash pass over the result set.
+--
+-- Replaces supervision_task_owner_index (single-column) with a composite index on
+-- (owner_id, status, planned_finishing_time). Column order follows the equality-first,
+-- range-last rule: owner_id and status are equality predicates in the common search
+-- filters; planned_finishing_time is a range predicate. The composite index is a strict
+-- superset of the old owner index, so the old index is dropped to avoid redundant write
+-- overhead.
+
+drop view allu.supervision_task_with_address;
+
+create view allu.supervision_task_with_address as
+  select s.id,s.application_id,s.type,s.creator_id,s.owner_id,s.creation_time,s.planned_finishing_time,s.actual_finishing_time,s.status,s.description,s.result,s.location_id,
+    case
+        when p.street_address is not null then array[]::text[] || p.street_address
+        else null
+    end as address
+    from allu.supervision_task s
+    inner join allu.location l on s.location_id=l.id
+    left join allu.postal_address p on l.postal_address_id=p.id
+  union all
+  select s.id,s.application_id,s.type,s.creator_id,s.owner_id,s.creation_time,s.planned_finishing_time,s.actual_finishing_time,s.status,s.description,s.result,s.location_id,a.address
+    from allu.supervision_task s
+    left join allu.application_address a on s.application_id=a.application_id
+    where s.location_id is null;
+
+drop index allu.supervision_task_owner_index;
+
+create index supervision_task_owner_status_time_index
+  on allu.supervision_task (owner_id, status, planned_finishing_time);

--- a/backend/model-service/src/test/java/fi/hel/allu/model/controller/SupervisionTaskDaoSpec.java
+++ b/backend/model-service/src/test/java/fi/hel/allu/model/controller/SupervisionTaskDaoSpec.java
@@ -148,12 +148,24 @@ public class SupervisionTaskDaoSpec extends SpeccyTestBase {
           final Sort sort = Sort.by(Sort.Order.asc("applicationId"),
                Sort.Order.desc("actualFinishingTime"));
           it("Can convert to QueryDSL ordering", () -> {
-            OrderSpecifier<?>[] orders = SupervisionTaskDao.toOrder(sort);
+            OrderSpecifier<?>[] orders = supervisionTaskDao.toOrder(sort);
             assertEquals(2, orders.length);
           });
 
           it("Throws exception on invalid sort key", () -> {
-            assertThrows(NoSuchEntityException.class).when(() -> SupervisionTaskDao.toOrder(Sort.by("noSuchKey")));
+            assertThrows(NoSuchEntityException.class).when(() -> supervisionTaskDao.toOrder(Sort.by("noSuchKey")));
+          });
+
+          it("All expected sort keys including CASE WHEN columns are resolvable", () -> {
+            List<String> expectedKeys = Arrays.asList(
+              "type", "application.type", "application.status",
+              "plannedFinishingTime", "application.applicationId",
+              "owner.realName", "creator.realName"
+            );
+            for (String key : expectedKeys) {
+              OrderSpecifier<?>[] orders = supervisionTaskDao.toOrder(Sort.by(key));
+              assertEquals("Sort key '" + key + "' should produce one OrderSpecifier", 1, orders.length);
+            }
           });
 
         });
@@ -177,6 +189,23 @@ public class SupervisionTaskDaoSpec extends SpeccyTestBase {
           // Warranty ("Takuuvalvonta") should precede Supervision ("Valvonta"):
           assertEquals(SupervisionTaskType.WARRANTY, result.getContent().get(0).getType());
           assertEquals(SupervisionTaskType.SUPERVISION, result.getContent().get(1).getType());
+        });
+
+        it("Sort by type with multiple task types verifies full Finnish alphabetical order", () -> {
+          supervisionTaskDao.insert(createTask(shortTermApp.getId(), SupervisionTaskType.PRELIMINARY_SUPERVISION, shortTermApp.getOwner()));
+          supervisionTaskDao.insert(createTask(shortTermApp.getId(), SupervisionTaskType.TERMINATION, shortTermApp.getOwner()));
+          supervisionTaskDao.insert(createTask(shortTermApp.getId(), SupervisionTaskType.WARRANTY, shortTermApp.getOwner()));
+          // existingSupervisionTask (SUPERVISION/"Valvonta") already exists from beforeEach
+
+          Pageable pageRequest = PageRequest.of(0, 10, Sort.by(Direction.ASC, "type"));
+          Page<SupervisionWorkItem> result = supervisionTaskDao.search(new SupervisionTaskSearchCriteria(), pageRequest);
+
+          assertEquals(4, result.getNumberOfElements());
+          // Finnish alphabetical: Aloitusvalvonta < Irtisanomisen valvonta < Takuuvalvonta < Valvonta
+          assertEquals(SupervisionTaskType.PRELIMINARY_SUPERVISION, result.getContent().get(0).getType());
+          assertEquals(SupervisionTaskType.TERMINATION, result.getContent().get(1).getType());
+          assertEquals(SupervisionTaskType.WARRANTY, result.getContent().get(2).getType());
+          assertEquals(SupervisionTaskType.SUPERVISION, result.getContent().get(3).getType());
         });
 
         it("Sort by application type when empty criteria", () -> {
@@ -208,6 +237,19 @@ public class SupervisionTaskDaoSpec extends SpeccyTestBase {
           assertEquals(shortTermApp.getId(), result.getContent().get(1).getApplicationId());
         });
 
+        it("Sort by type DESC reverses Finnish alphabetical order", () -> {
+          supervisionTaskDao.insert(createTask(shortTermApp.getId(), SupervisionTaskType.WARRANTY, shortTermApp.getOwner()));
+          // existingSupervisionTask (SUPERVISION/"Valvonta") from beforeEach
+
+          Pageable pageRequest = PageRequest.of(0, 10, Sort.by(Direction.DESC, "type"));
+          Page<SupervisionWorkItem> result = supervisionTaskDao.search(new SupervisionTaskSearchCriteria(), pageRequest);
+
+          assertEquals(2, result.getNumberOfElements());
+          // DESC Finnish: Valvonta > Takuuvalvonta
+          assertEquals(SupervisionTaskType.SUPERVISION, result.getContent().get(0).getType());
+          assertEquals(SupervisionTaskType.WARRANTY, result.getContent().get(1).getType());
+        });
+
         it("Sort by non-enum column plannedFinishingTime", () -> {
           SupervisionTask laterTask = createTask(shortTermApp.getId(), SupervisionTaskType.WARRANTY, shortTermApp.getOwner());
           laterTask.setPlannedFinishingTime(testTime.plusDays(30));
@@ -235,6 +277,33 @@ public class SupervisionTaskDaoSpec extends SpeccyTestBase {
           assertTrue("Application IDs should be in ascending order",
             result.getContent().get(0).getApplicationIdText()
               .compareTo(result.getContent().get(1).getApplicationIdText()) <= 0);
+        });
+
+        it("Sort by enum and non-enum columns combined", () -> {
+          SupervisionTask warranty1 = createTask(shortTermApp.getId(), SupervisionTaskType.WARRANTY, shortTermApp.getOwner());
+          warranty1.setPlannedFinishingTime(testTime.plusDays(30));
+          supervisionTaskDao.insert(warranty1);
+
+          SupervisionTask warranty2 = createTask(shortTermApp.getId(), SupervisionTaskType.WARRANTY, shortTermApp.getOwner());
+          warranty2.setPlannedFinishingTime(testTime.plusDays(5));
+          supervisionTaskDao.insert(warranty2);
+          // existingSupervisionTask: SUPERVISION/"Valvonta", plannedFinishingTime = testTime+1day
+
+          Pageable pageRequest = PageRequest.of(0, 10, Sort.by(
+            new Order(Direction.ASC, "type"),
+            new Order(Direction.DESC, "plannedFinishingTime")
+          ));
+          Page<SupervisionWorkItem> result = supervisionTaskDao.search(new SupervisionTaskSearchCriteria(), pageRequest);
+
+          assertEquals(3, result.getNumberOfElements());
+          // First two: WARRANTY (Takuuvalvonta) sorted by plannedFinishingTime DESC
+          assertEquals(SupervisionTaskType.WARRANTY, result.getContent().get(0).getType());
+          assertEquals(SupervisionTaskType.WARRANTY, result.getContent().get(1).getType());
+          assertTrue("WARRANTY tasks should be sorted by plannedFinishingTime DESC",
+            result.getContent().get(0).getPlannedFinishingTime()
+              .isAfter(result.getContent().get(1).getPlannedFinishingTime()));
+          // Last: SUPERVISION (Valvonta)
+          assertEquals(SupervisionTaskType.SUPERVISION, result.getContent().get(2).getType());
         });
 
         it("Find by application id", () -> {
@@ -394,6 +463,9 @@ public class SupervisionTaskDaoSpec extends SpeccyTestBase {
           // Enriched fields from owner join
           assertEquals("realname", item.getOwnerRealName());
           assertEquals("enrichedowner", item.getOwnerUserName());
+
+          // Project name from project join
+          assertNotNull("projectName should be populated from project join", item.getProjectName());
         });
 
         context("Count query consistency", () -> {

--- a/backend/model-service/src/test/java/fi/hel/allu/model/controller/SupervisionTaskDaoSpec.java
+++ b/backend/model-service/src/test/java/fi/hel/allu/model/controller/SupervisionTaskDaoSpec.java
@@ -25,6 +25,7 @@ import com.greghaskins.spectrum.Variable;
 import com.querydsl.core.types.OrderSpecifier;
 
 import fi.hel.allu.common.domain.SupervisionTaskSearchCriteria;
+import fi.hel.allu.common.domain.types.ApplicationType;
 import fi.hel.allu.common.domain.types.StatusType;
 import fi.hel.allu.common.domain.types.SupervisionTaskStatusType;
 import fi.hel.allu.common.domain.types.SupervisionTaskType;
@@ -349,6 +350,50 @@ public class SupervisionTaskDaoSpec extends SpeccyTestBase {
           SupervisionTaskSearchCriteria location2Search = new SupervisionTaskSearchCriteria();
           location2Search.setCityDistrictIds(Arrays.asList(location2.getCityDistrictIdOverride()));
           assertEquals("Expected to find single task", 1, supervisionTaskDao.search(location2Search, PageRequest.of(0, 100)).getTotalElements());
+        });
+
+        it("Search projects enriched fields correctly", () -> {
+          Application app = insertApplication(testCommon.dummyOutdoorApplicationWithLocation("enriched", "enrichedOwner"));
+          Location location = app.getLocations().get(0);
+
+          SupervisionTask task = createTask(app.getId(), SupervisionTaskType.WARRANTY, app.getOwner());
+          task.setLocationId(location.getId());
+          SupervisionTask inserted = supervisionTaskDao.insert(task);
+
+          SupervisionTaskSearchCriteria search = new SupervisionTaskSearchCriteria();
+          search.setApplicationIds(Arrays.asList(app.getId()));
+          search.setStatuses(Arrays.asList(SupervisionTaskStatusType.OPEN));
+
+          Page<SupervisionWorkItem> page = supervisionTaskDao.search(search, PageRequest.of(0, 100));
+          assertEquals(1, page.getTotalElements());
+
+          SupervisionWorkItem item = page.getContent().get(0);
+
+          // Pre-existing fields
+          assertEquals(inserted.getId(), item.getId());
+          assertEquals(app.getId(), item.getApplicationId());
+          assertNotNull(item.getApplicationIdText());
+          assertEquals(SupervisionTaskType.WARRANTY, item.getType());
+          assertNotNull(item.getAddress());
+
+          // Enriched fields from application join
+          assertEquals(ApplicationType.EVENT, item.getApplicationType());
+          assertEquals(app.getStatus(), item.getApplicationStatus());
+
+          // Enriched fields from supervision task view
+          assertEquals(SupervisionTaskStatusType.OPEN, item.getTaskStatus());
+          assertNotNull(item.getCreationTime());
+          assertEquals("just testing", item.getDescription());
+          assertNull(item.getResult());
+          assertNull(item.getActualFinishingTime());
+
+          // Enriched fields from location join
+          assertEquals(location.getId(), item.getLocationId());
+          assertEquals(location.getLocationKey(), item.getLocationKey());
+
+          // Enriched fields from owner join
+          assertEquals("realname", item.getOwnerRealName());
+          assertEquals("enrichedowner", item.getOwnerUserName());
         });
 
         context("Count query consistency", () -> {

--- a/backend/model-service/src/test/java/fi/hel/allu/model/controller/SupervisionTaskDaoSpec.java
+++ b/backend/model-service/src/test/java/fi/hel/allu/model/controller/SupervisionTaskDaoSpec.java
@@ -322,6 +322,70 @@ public class SupervisionTaskDaoSpec extends SpeccyTestBase {
           assertEquals("Expected to find single task", 1, supervisionTaskDao.search(location2Search, PageRequest.of(0, 100)).getTotalElements());
         });
 
+        context("Count query consistency", () -> {
+          it("Count matches results when filtering by application type", () -> {
+            SupervisionTask taskForOther = createTask(shortTermApp.getId(), SupervisionTaskType.SUPERVISION, shortTermApp.getOwner());
+            supervisionTaskDao.insert(taskForOther);
+
+            SupervisionTaskSearchCriteria search = new SupervisionTaskSearchCriteria();
+            search.setApplicationTypes(Arrays.asList(outdoorApp.getType()));
+
+            Page<SupervisionWorkItem> page = supervisionTaskDao.search(search, PageRequest.of(0, 100));
+            assertEquals(1, page.getTotalElements());
+            assertEquals(page.getContent().size(), page.getTotalElements());
+          });
+
+          it("Count matches results when filtering by application ID prefix", () -> {
+            SupervisionTask taskForOther = createTask(shortTermApp.getId(), SupervisionTaskType.SUPERVISION, shortTermApp.getOwner());
+            supervisionTaskDao.insert(taskForOther);
+
+            SupervisionTaskSearchCriteria search = new SupervisionTaskSearchCriteria();
+            search.setApplicationId(outdoorApp.getApplicationId());
+
+            Page<SupervisionWorkItem> page = supervisionTaskDao.search(search, PageRequest.of(0, 100));
+            assertEquals(1, page.getTotalElements());
+            assertEquals(page.getContent().size(), page.getTotalElements());
+          });
+
+          it("Count matches results when filtering by application status", () -> {
+            SupervisionTask taskForOther = createTask(shortTermApp.getId(), SupervisionTaskType.SUPERVISION, shortTermApp.getOwner());
+            supervisionTaskDao.insert(taskForOther);
+
+            applicationDao.updateStatus(outdoorApp.getId(), StatusType.HANDLING);
+            applicationDao.updateStatus(shortTermApp.getId(), StatusType.CANCELLED);
+
+            SupervisionTaskSearchCriteria search = new SupervisionTaskSearchCriteria();
+            search.setApplicationStatus(Arrays.asList(StatusType.HANDLING));
+
+            Page<SupervisionWorkItem> page = supervisionTaskDao.search(search, PageRequest.of(0, 100));
+            assertEquals(1, page.getTotalElements());
+            assertEquals(page.getContent().size(), page.getTotalElements());
+          });
+
+          it("Count matches results when filtering by city district", () -> {
+            Application app1 = insertApplication(testCommon.dummyOutdoorApplicationWithLocation("event1", "owner1"));
+            Location location1 = app1.getLocations().get(0);
+
+            SupervisionTask task1 = createTask(app1.getId(), SupervisionTaskType.SUPERVISION, app1.getOwner());
+            task1.setLocationId(location1.getId());
+            supervisionTaskDao.insert(task1);
+
+            Application app2 = testCommon.dummyOutdoorApplicationWithLocation("event2", "owner2");
+            app2.getLocations().get(0).setCityDistrictIdOverride(2);
+            app2 = insertApplication(app2);
+
+            SupervisionTask task2 = createTask(app2.getId(), SupervisionTaskType.SUPERVISION, app2.getOwner());
+            supervisionTaskDao.insert(task2);
+
+            SupervisionTaskSearchCriteria search = new SupervisionTaskSearchCriteria();
+            search.setCityDistrictIds(Arrays.asList(location1.getCityDistrictId()));
+
+            Page<SupervisionWorkItem> page = supervisionTaskDao.search(search, PageRequest.of(0, 100));
+            assertEquals(page.getContent().size(), page.getTotalElements());
+            assertTrue("Expected at least one result", page.getTotalElements() >= 1);
+          });
+        });
+
         context("Paging tests", () -> {
           final Variable<Page<SupervisionWorkItem>> results = new Variable<>();
 

--- a/backend/model-service/src/test/java/fi/hel/allu/model/controller/SupervisionTaskDaoSpec.java
+++ b/backend/model-service/src/test/java/fi/hel/allu/model/controller/SupervisionTaskDaoSpec.java
@@ -207,6 +207,35 @@ public class SupervisionTaskDaoSpec extends SpeccyTestBase {
           assertEquals(shortTermApp.getId(), result.getContent().get(1).getApplicationId());
         });
 
+        it("Sort by non-enum column plannedFinishingTime", () -> {
+          SupervisionTask laterTask = createTask(shortTermApp.getId(), SupervisionTaskType.WARRANTY, shortTermApp.getOwner());
+          laterTask.setPlannedFinishingTime(testTime.plusDays(30));
+          supervisionTaskDao.insert(laterTask);
+
+          Pageable pageRequest = PageRequest.of(0, 10, Sort.by(Direction.ASC, "plannedFinishingTime"));
+          Page<SupervisionWorkItem> result = supervisionTaskDao.search(new SupervisionTaskSearchCriteria(), pageRequest);
+
+          assertEquals(2, result.getNumberOfElements());
+          // existingSupervisionTask has plannedFinishingTime = testTime+1day, laterTask = testTime+30days
+          assertTrue("Earlier task should come first",
+            result.getContent().get(0).getPlannedFinishingTime()
+              .isBefore(result.getContent().get(1).getPlannedFinishingTime()));
+        });
+
+        it("Sort by non-enum column application.applicationId", () -> {
+          SupervisionTask taskForOther = createTask(shortTermApp.getId(), SupervisionTaskType.WARRANTY, shortTermApp.getOwner());
+          supervisionTaskDao.insert(taskForOther);
+
+          Pageable pageRequest = PageRequest.of(0, 10, Sort.by(Direction.ASC, "application.applicationId"));
+          Page<SupervisionWorkItem> result = supervisionTaskDao.search(new SupervisionTaskSearchCriteria(), pageRequest);
+
+          assertEquals(2, result.getNumberOfElements());
+          // Verify ascending order by applicationIdText
+          assertTrue("Application IDs should be in ascending order",
+            result.getContent().get(0).getApplicationIdText()
+              .compareTo(result.getContent().get(1).getApplicationIdText()) <= 0);
+        });
+
         it("Find by application id", () -> {
           SupervisionTask taskForOther = createTask(shortTermApp.getId(), SupervisionTaskType.SUPERVISION, shortTermApp.getOwner());
           supervisionTaskDao.insert(taskForOther);

--- a/backend/supervision-api/src/main/java/fi/hel/allu/supervision/api/mapper/SupervisionTaskMapper.java
+++ b/backend/supervision-api/src/main/java/fi/hel/allu/supervision/api/mapper/SupervisionTaskMapper.java
@@ -29,11 +29,38 @@ public class SupervisionTaskMapper {
   @Autowired
   private LocationService locationService;
 
+  /**
+   * Maps a search query work item directly to a search result without any
+   * additional HTTP calls. All needed fields are fetched by the enriched
+   * search query projection.
+   */
   public SupervisionTaskSearchResult mapToSearchResult(SupervisionWorkItem item) {
-    SupervisionTaskJson task = supervisionTaskService.findById(item.getId());
-    return mapToSearchResult(task, item.getAddress());
+    SupervisionTaskSearchResult result = new SupervisionTaskSearchResult();
+    result.setId(item.getId());
+    result.setApplicationId(item.getApplicationId());
+    result.setApplicationIdentifier(item.getApplicationIdText());
+    result.setApplicationStatus(item.getApplicationStatus());
+    result.setApplicationType(item.getApplicationType());
+    result.setType(item.getType());
+    result.setOwnerRealName(item.getOwnerRealName());
+    result.setOwnerUserName(item.getOwnerUserName());
+    result.setCreationTime(item.getCreationTime());
+    result.setPlannedFinishingTime(item.getPlannedFinishingTime());
+    result.setActualFinishingTime(item.getActualFinishingTime());
+    result.setStatus(item.getTaskStatus());
+    result.setDescription(item.getDescription());
+    result.setResult(item.getResult());
+    result.setLocationId(item.getLocationId());
+    result.setLocationKey(item.getLocationKey());
+    result.setAddresses(Optional.ofNullable(item.getAddress()).map(Arrays::asList).orElse(Collections.emptyList()));
+    return result;
   }
 
+  /**
+   * Maps a single supervision task JSON (fetched by ID) to a search result.
+   * Used by the findById and findByApplicationId endpoints which don't go
+   * through the search query. This path still requires individual HTTP calls.
+   */
   public SupervisionTaskSearchResult mapToSearchResult(SupervisionTaskJson task) {
     return mapToSearchResult(task, supervisionTaskService.getTaskAddresses(task.getId()));
   }


### PR DESCRIPTION
# Changes
- Replace `UNION` with `UNION ALL` in `supervision_task_with_address` view — the two branches are mutually exclusive (`location_id IS NOT NULL` vs `IS NULL`), so deduplication was a no-op wasting a full sort/hash pass
- Add composite index (owner_id, status, planned_finishing_time) — covers the most common filter pattern; replaces the single-column owner_id index
- Lightweight count query — counts against the base `supervision_task` table instead of the full view with all its joins; only joins application when search criteria reference application fields
- Conditional enum sort joins — the 6 structure_meta/attribute_meta `LEFT JOIN`s for enum display names are now only added when actually sorting by an enum column
- Eliminate N+1 HTTP calls — enriched the `SupervisionWorkItem` projection to include application, owner, and location fields directly from the SQL query, replacing 2-5 HTTP round-trips per result row in the supervision-api mapper
- Remove unnecessary project `LEFT JOIN` — project.name is not used as a sort field or displayed in search results
- Mark search as `@Transactional(readOnly = true)` — enables PostgreSQL read-only optimizations

https://helsinkisolutionoffice.atlassian.net/browse/ALLU-185