### PR TITLE
ALLU-206: Handle invalid application geometries gracefully on map

### DIFF
--- a/frontend/src/app/feature/map/map.component.ts
+++ b/frontend/src/app/feature/map/map.component.ts
@@ -22,6 +22,7 @@ import {MapFeatureInfo} from '@service/map/map-feature-info';
 import {EnumUtil} from '@util/enum.util';
 import {ApplicationType} from '@model/application/type/application-type';
 import {FixedLocation} from '@model/common/fixed-location';
+import {NotificationService} from '../notification/notification.service';
 
 @Component({
   selector: 'map',
@@ -46,13 +47,15 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   loading$: Observable<boolean>;
 
   private destroy = new Subject<boolean>();
+  private reportedGeometryErrors = new Set<string>();
 
   constructor(
     private mapStore: MapStore,
     private projectService: ProjectService,
     private mapController: MapController,
     private store: Store<fromRoot.State>,
-    private mapUtil: MapUtil) {}
+    private mapUtil: MapUtil,
+    private notification: NotificationService) {}
 
   ngOnInit() {
     this.mapStore.roleChange(this.role);
@@ -120,6 +123,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private drawApplications(applications: Array<Application>) {
+    const failedApplicationIds: string[] = [];
     const drawnApplications = applications
       .filter(app => this.applicationShouldBeDrawn(app))
       .filter(app => app.id !== this.applicationId); // Only draw other than edited application
@@ -127,7 +131,11 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     const featureGroupsByType = drawnApplications.reduce((acc, app) => {
       const featureCollections = app.locations
         .map(loc => loc.geometry)
-        .map(gc => this.mapUtil.createFeatureCollection(gc, this.createFeatureInfo(app)));
+        .map(gc => this.mapUtil.createFeatureCollection(gc, this.createFeatureInfo(app), () => {
+          if (!failedApplicationIds.includes(app.applicationId)) {
+            failedApplicationIds.push(app.applicationId);
+          }
+        }));
 
       if (acc[app.type] === undefined) {
         acc[app.type] = this.mapUtil.mergeFeatureCollections(featureCollections);
@@ -137,6 +145,14 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
       }
       return acc;
     }, {});
+
+    if (failedApplicationIds.length > 0) {
+      const newFailures = failedApplicationIds.filter(id => !this.reportedGeometryErrors.has(id));
+      if (newFailures.length > 0) {
+        newFailures.forEach(id => this.reportedGeometryErrors.add(id));
+        this.notification.error(findTranslation('map.applicationGeometryError'), newFailures.join('<br>'), true, true);
+      }
+    }
 
     EnumUtil.enumValues(ApplicationType).forEach(type => {
       const layerName = findTranslation(['application.type', type]);

--- a/frontend/src/app/feature/notification/notification.service.ts
+++ b/frontend/src/app/feature/notification/notification.service.ts
@@ -35,8 +35,8 @@ export class NotificationService {
     this.toastService.info(message, title);
   }
 
-  error(title: string, message?: string, disableTimeOut: boolean = true): void {
-    this.toastService.error(message, title, {disableTimeOut});
+  error(title: string, message?: string, disableTimeOut: boolean = true, enableHtml: boolean = false): void {
+    this.toastService.error(message, title, {disableTimeOut, enableHtml});
   }
 
   errorInfo(errorInfo: ErrorInfo): void {

--- a/frontend/src/app/service/map/map.util.ts
+++ b/frontend/src/app/service/map/map.util.ts
@@ -45,11 +45,20 @@ export class MapUtil {
     return geometryCollection;
   }
 
-  public createFeatureCollection(geometryCollection?: GeometryCollection, featureInfo?: MapFeatureInfo):
+  public createFeatureCollection(geometryCollection?: GeometryCollection, featureInfo?: MapFeatureInfo,
+                                  onError?: (err: Error) => void):
     FeatureCollection<GeometryObject> {
     const features = Some(geometryCollection)
       .map(gc => gc.geometries)
-      .map(geometries => geometries.map(g => this.createFeature(g, featureInfo)))
+      .map(geometries => geometries.reduce((acc, g) => {
+        try {
+          acc.push(this.createFeature(g, featureInfo));
+        } catch (e) {
+          console.error('Failed to create feature for geometry', g, e);
+          if (onError) { onError(e); }
+        }
+        return acc;
+      }, [] as Feature<GeometryObject>[]))
       .orElse([]);
 
     return this.wrapToFeatureCollection(features);

--- a/frontend/src/app/util/translations.ts
+++ b/frontend/src/app/util/translations.ts
@@ -1405,6 +1405,7 @@ export const translations = {
     areasIntersect: 'Alue leikkaa toisen alueen',
     areaIntersects: 'Alue leikkaa itsensä',
     focusOnApplication: 'Tarkenna hakemukseen',
+    applicationGeometryError: 'Seuraavien hakemusten sijaintien piirtäminen kartalle epäonnistui',
     draw: {
       toolbar: {
         actions: {

--- a/frontend/src/test/map.util.spec.ts
+++ b/frontend/src/test/map.util.spec.ts
@@ -38,6 +38,58 @@ describe('MapService', () => {
     expect(processedGeoJSON).toBe(roundedOriginalGeoJSON);
   });
 
+  it('should not throw and should skip nested GeometryCollection geometries gracefully', () => {
+    const mapService = new MapUtil(new Projection());
+
+    // The unproject() helper assumes .coordinates exists, but GeometryCollection has
+    // .geometries instead — causing "TypeError: Cannot read properties of undefined (reading '0')"
+    // which aborts the entire Array.map and prevents all applications from being drawn.
+    const geoJSON = {
+      type: 'GeometryCollection',
+      crs: { type: 'name', properties: { name: 'EPSG:3879' } },
+      geometries: [
+        {
+          // Valid polygon — should still be rendered after the fix
+          type: 'Polygon',
+          coordinates: [
+            [
+              [25500000, 6700000],
+              [25500100, 6700000],
+              [25500100, 6700100],
+              [25500000, 6700000]
+            ]
+          ]
+        },
+        {
+          // Nested GeometryCollection — has no .coordinates, only .geometries, which causes
+          // "TypeError: Cannot read properties of undefined (reading '0')" in unproject().
+          type: 'GeometryCollection',
+          geometries: [
+            {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [25501000, 6701000],
+                  [25501100, 6701000],
+                  [25501100, 6701100],
+                  [25501000, 6701000]
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    // Before the fix this throws:
+    // "TypeError: Cannot read properties of undefined (reading '0')"
+    expect(() => mapService.createFeatureCollection(geoJSON as any)).not.toThrow();
+
+    // The valid polygon should still produce a feature — the bad geometry must not
+    // abort the entire collection
+    const fc = mapService.createFeatureCollection(geoJSON as any);
+    expect(fc.features.length).toBeGreaterThanOrEqual(1);
+  });
 });
 
 class Helper {


### PR DESCRIPTION
A nested GeometryCollection in application location geometry caused createFeatureCollection() to throw, preventing all applications from rendering on the map.

https://helsinkisolutionoffice.atlassian.net/browse/ALLU-206