### PR TITLE
ALLU-197-202: Muutoksia päätöksiin ja rekisterinumero-kentän lisääminen

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,6 @@ Add `search-service` for good measure.
 Go to the `allu-ui-service-test` directory: `cd backend/allu-ui-service-test/`.
 Directory should have package.json file. Run `npm install`.
 
-To run 10 different applications into the database, run `TEST_TARGET=http://localhost:3000 npm test`.
+To run 12 different applications into the database, run `TEST_TARGET=http://localhost:3000 npm test`.
 To run the massdata test, run `TEST_TARGET=http://localhost:3000 npm test "massdata/*"`. Note that it takes a long time,
 as it inserts 10 000 applications. 

--- a/backend/allu-ui-service-test/spec/draft-application.spec.js
+++ b/backend/allu-ui-service-test/spec/draft-application.spec.js
@@ -127,13 +127,95 @@ describe('Application draft', () => {
       'endTime': applicationEndTime,
       'customersWithContacts': [applicantCustomersWithContactsCreated],
       'extension': {
-        'applicationType': 'SHORT_TERM_RENTAL'
+        'applicationType': 'SHORT_TERM_RENTAL',
+        'registrationNumbers': null
       },
 
     };
 
 
     let options = TestUtil.getPostOptions('/api/drafts', draft);
+    TestUtil.login('kasittelija')
+    .then(token => TestUtil.addAuthorization(options, token))
+    .then(() => rp(options))
+    .then(done, done.fail);
+  });
+
+  it('Create draft with registrationNumbers', done => {
+    const draftWithRegNumbers = {
+      'type': 'SHORT_TERM_RENTAL',
+      'kindsWithSpecifiers': {'SEASON_SALE': []},
+      'locations': [
+          {
+            'id': null,
+            'startTime': applicationStartTime,
+            'endTime': applicationEndTime,
+            'geometry': {
+              'type': 'GeometryCollection',
+              'crs': {
+                'properties': {
+                  'name': 'EPSG:3879'
+                },
+                'type': 'name'
+              },
+              'bbox': null,
+              'geometries': [
+                {
+                  'type': 'Polygon',
+                  'crs': null,
+                  'bbox': [
+                    2.549815796449239E7,
+                    6672928.0334480135,
+                    2.5498190016256575E7,
+                    6672968.0474401545],
+                  'coordinates': [
+                    [
+                      [
+                        2.549815796449239E7,
+                        6672928.049400462
+                      ],
+                      [
+                        2.5498157984586794E7,
+                        6672968.0474401545
+                      ],
+                      [
+                        2.5498190016256575E7,
+                        6672968.031487824
+                      ],
+                      [
+                        2.5498189996511605E7,
+                        6672928.0334480135
+                      ],
+                      [
+                        2.549815796449239E7,
+                        6672928.049400462
+                      ]
+                    ]
+                  ]
+                }
+              ]
+            },
+            'area': 1281.2113072694833,
+            'areaOverride': null,
+            'postalAddress': {
+              'streetAddress': null,
+              'postalCode': null,
+              'city': null
+            },
+            'fixedLocationIds': []
+          }
+        ],
+      'name': 'Sesonkimyynnin alustava varaus',
+      'startTime': applicationStartTime,
+      'endTime': applicationEndTime,
+      'customersWithContacts': [applicantCustomersWithContactsCreated],
+      'extension': {
+        'applicationType': 'SHORT_TERM_RENTAL',
+        'registrationNumbers': 'ABC-123, DEF-456'
+      },
+    };
+
+    let options = TestUtil.getPostOptions('/api/drafts', draftWithRegNumbers);
     TestUtil.login('kasittelija')
     .then(token => TestUtil.addAuthorization(options, token))
     .then(() => rp(options))

--- a/backend/allu-ui-service-test/spec/short-term-rental-application.spec.js
+++ b/backend/allu-ui-service-test/spec/short-term-rental-application.spec.js
@@ -119,7 +119,8 @@ describe('Short term rental application', () => {
         'extension': {
           'applicationType': 'SHORT_TERM_RENTAL',
           'description': 'Porkkalan siltamainos',
-          'commercial': true
+          'commercial': true,
+          'registrationNumbers': null
         },
         'invoicingDate': '2018-12-22T22:00:00Z',
 	'startTime': applicationStartTime,
@@ -128,6 +129,81 @@ describe('Short term rental application', () => {
 
 
     let options = TestUtil.getPostOptions('/api/applications', shortTermRentalApplication);
+    TestUtil.login('kasittelija')
+      .then(token => TestUtil.addAuthorization(options, token))
+      .then(() => rp(options))
+      .then(done, done.fail);
+  });
+
+  it('Create with registrationNumbers', done => {
+
+    const shortTermRentalWithRegNumbers = {
+        'id': null,
+        'handler': null,
+        'status': null,
+        'type': 'SHORT_TERM_RENTAL',
+        'kindsWithSpecifiers': {'BENJI': []},
+        'notBillable': 'false',
+        'name': 'Benji-hyppylaite Porkkalassa',
+        'decisionPublicityType': 'PUBLIC',
+        'creationTime': '2016-07-15T10:36:09.721Z',
+        'customersWithContacts': [applicantCustomersWithContactsCreated],
+        'locations': [
+          {
+            'id': null,
+            'startTime': applicationStartTime,
+            'endTime': applicationEndTime,
+            'geometry': {
+              'type': 'GeometryCollection',
+              'crs': {
+                'properties': {
+                  'name': 'EPSG:3879'
+                },
+                'type': 'name'
+              },
+              'bbox': null,
+              'geometries': [
+                {
+                  'type': 'Point',
+                  'crs': null,
+                  'bbox': [
+                    2.5495613592870224E7,
+                    6672428.889279648,
+                    2.5495613592870224E7,
+                    6672428.889279648
+                  ],
+                  'coordinates': [
+                    2.5495613592870224E7,
+                    6672428.889279648
+                  ]
+                }
+              ]
+            },
+            'area': 0.0,
+            'areaOverride': null,
+            'underpass': false,
+            'postalAddress': {
+              'streetAddress': null,
+              'postalCode': null,
+              'city': null
+            },
+            'fixedLocationIds': [
+              62
+            ]
+          }
+        ],
+        'extension': {
+          'applicationType': 'SHORT_TERM_RENTAL',
+          'description': 'Benji-hyppylaite rannalla',
+          'commercial': true,
+          'registrationNumbers': 'ABC-123, DEF-456, GHI-789'
+        },
+        'invoicingDate': '2018-12-22T22:00:00Z',
+        'startTime': applicationStartTime,
+        'endTime': applicationEndTime
+    };
+
+    let options = TestUtil.getPostOptions('/api/applications', shortTermRentalWithRegNumbers);
     TestUtil.login('kasittelija')
       .then(token => TestUtil.addAuthorization(options, token))
       .then(() => rp(options))

--- a/backend/model-domain/src/main/java/fi/hel/allu/model/domain/ShortTermRental.java
+++ b/backend/model-domain/src/main/java/fi/hel/allu/model/domain/ShortTermRental.java
@@ -9,6 +9,7 @@ public class ShortTermRental extends ApplicationExtension {
   private String description;
   private Boolean commercial;
   private Boolean billableSalesArea;
+  private String registrationNumbers;
 
   @Override
   public ApplicationType getApplicationType() {
@@ -40,5 +41,13 @@ public class ShortTermRental extends ApplicationExtension {
 
   public void setBillableSalesArea(Boolean billableSalesArea) {
     this.billableSalesArea = billableSalesArea;
+  }
+
+  public String getRegistrationNumbers() {
+    return registrationNumbers;
+  }
+
+  public void setRegistrationNumbers(String registrationNumbers) {
+    this.registrationNumbers = registrationNumbers;
   }
 }

--- a/backend/model-service/src/main/resources/db/migration/V199__add_registration_numbers_metadata.sql
+++ b/backend/model-service/src/main/resources/db/migration/V199__add_registration_numbers_metadata.sql
@@ -1,0 +1,3 @@
+-- Add registrationNumbers attribute metadata for SHORT_TERM_RENTAL extension
+INSERT INTO allu.attribute_meta (structure_meta_id, name, ui_name, data_type, list_type, structure_attribute)
+    VALUES ((select id from allu.structure_meta where type_name = 'SHORT_TERM_RENTAL'), 'registrationNumbers', 'Rekisterinumerot', 'STRING', null, null);

--- a/backend/pdf-domain/src/main/java/fi/hel/allu/pdf/domain/DecisionJson.java
+++ b/backend/pdf-domain/src/main/java/fi/hel/allu/pdf/domain/DecisionJson.java
@@ -59,6 +59,7 @@ public class DecisionJson {
 
   private String eventName;
   private String eventDescription;
+  private String registrationNumbers;
   private String eventUrl;
   private String eventNature;
   private String structureArea;
@@ -438,6 +439,14 @@ public class DecisionJson {
 
   public void setEventDescription(String eventDescription) {
     this.eventDescription = eventDescription;
+  }
+
+  public String getRegistrationNumbers() {
+    return registrationNumbers;
+  }
+
+  public void setRegistrationNumbers(String registrationNumbers) {
+    this.registrationNumbers = registrationNumbers;
   }
 
   public String getEventUrl() {

--- a/backend/pdf-service/stylesheets/SHORT_TERM_RENTAL.xsl
+++ b/backend/pdf-service/stylesheets/SHORT_TERM_RENTAL.xsl
@@ -174,6 +174,16 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
         </section>
       </div>
 
+      <!-- Rekisterinumerot – ei näytetä anonymisoidussa versiossa -->
+      <xsl:if test="data/registrationNumbers != '' and data/anonymizedDocument = 'false'">
+        <section class="unboxed">
+          <h1>Rekisterinumerot</h1>
+          <p>
+            <xsl:value-of select="data/registrationNumbers"/>
+          </p>
+        </section>
+      </xsl:if>
+
       <xsl:if test="data/notBillable = 'false' and data/chargeInfoEntries">
         <section class="unboxed">
           <h1>Vuokran erittely</h1>

--- a/backend/service-core-domain/src/main/java/fi/hel/allu/servicecore/domain/ShortTermRentalJson.java
+++ b/backend/service-core-domain/src/main/java/fi/hel/allu/servicecore/domain/ShortTermRentalJson.java
@@ -10,6 +10,7 @@ public class ShortTermRentalJson extends ApplicationExtensionJson {
   private String description;
   private Boolean commercial;
   private Boolean billableSalesArea;
+  private String registrationNumbers;
 
   @Schema(description = "Application type (always SHORT_TERM_RENTAL).", allowableValues="SHORT_TERM_REANTAL", required = true)
   @Override
@@ -45,5 +46,15 @@ public class ShortTermRentalJson extends ApplicationExtensionJson {
   @UpdatableProperty
   public void setBillableSalesArea(Boolean billableSalesArea) {
     this.billableSalesArea = billableSalesArea;
+  }
+
+  @Schema(description = "Registration numbers for vehicles related to the rental")
+  public String getRegistrationNumbers() {
+    return registrationNumbers;
+  }
+
+  @UpdatableProperty
+  public void setRegistrationNumbers(String registrationNumbers) {
+    this.registrationNumbers = registrationNumbers;
   }
 }

--- a/backend/service-core/src/main/java/fi/hel/allu/servicecore/mapper/CustomerAnonymizer.java
+++ b/backend/service-core/src/main/java/fi/hel/allu/servicecore/mapper/CustomerAnonymizer.java
@@ -16,6 +16,25 @@ public class CustomerAnonymizer {
 
   private static final String ANONYMIZED_NAME = "Yksityishenkilö";
 
+  /**
+   * Truncates a customer name at the first occurrence of ';' or 'c/o'
+   * (case-insensitive, optional whitespace around '/'). This ensures that
+   * SAP name rows 2–5 and c/o suffixes are not visible in publishable
+   * anonymized decisions.
+   *
+   * Examples:
+   *   "Acme Oy; Toinen rivi"       → "Acme Oy"
+   *   "Acme Oy c/o Joku Henkilö"   → "Acme Oy"
+   *   "Acme Oy C / O Joku Henkilö" → "Acme Oy"
+   *   "Pelkkä Nimi"                → "Pelkkä Nimi"
+   */
+  static String sanitizeName(String name) {
+    if (name == null) {
+      return null;
+    }
+    return name.split("(?i);|c\\s*/\\s*o")[0].trim();
+  }
+
   public Optional<CustomerWithContactsJson> anonymizeCustomerWithContacts(Optional<CustomerWithContactsJson> cwc) {
     return cwc.map(c ->
         new CustomerWithContactsJson(
@@ -32,7 +51,7 @@ public class CustomerAnonymizer {
       anonymizedCustomer.setPostalAddress(new PostalAddressJson());
     } else {
       anonymizedCustomer.setId(customer.getId());
-      anonymizedCustomer.setName(customer.getName());
+      anonymizedCustomer.setName(sanitizeName(customer.getName()));
       anonymizedCustomer.setActive(customer.isActive());
       anonymizedCustomer.setCountry(customer.getCountry());
       anonymizedCustomer.setInvoicingOnly(customer.isInvoicingOnly());

--- a/backend/service-core/src/main/java/fi/hel/allu/servicecore/mapper/CustomerAnonymizer.java
+++ b/backend/service-core/src/main/java/fi/hel/allu/servicecore/mapper/CustomerAnonymizer.java
@@ -59,7 +59,6 @@ public class CustomerAnonymizer {
       anonymizedCustomer.setInvoicingOperator(customer.getInvoicingOperator());
       anonymizedCustomer.setOvt(customer.getOvt());
       anonymizedCustomer.setProjectIdentifierPrefix(customer.getProjectIdentifierPrefix());
-      anonymizedCustomer.setRegistryKey(customer.getRegistryKey());
       anonymizedCustomer.setSapCustomerNumber(customer.getSapCustomerNumber());
       anonymizedCustomer.setType(customer.getType());
       anonymizedCustomer.setPostalAddress(new PostalAddressJson());

--- a/backend/service-core/src/main/java/fi/hel/allu/servicecore/mapper/DecisionJsonMapper.java
+++ b/backend/service-core/src/main/java/fi/hel/allu/servicecore/mapper/DecisionJsonMapper.java
@@ -333,6 +333,7 @@ public class DecisionJsonMapper extends AbstractDocumentMapper<DecisionJson> {
       decisionJson
           .setEventNature("Lyhytaikainen maanvuokraus, " + translate(application.getKind()));
       decisionJson.setEventDescription(strj.getDescription());
+      decisionJson.setRegistrationNumbers(strj.getRegistrationNumbers());
     }
     if (ApplicationKind.BRIDGE_BANNER.equals(application.getKind())) {
       // For bridge banners, site area should be skipped in printout

--- a/backend/service-core/src/main/java/fi/hel/allu/servicecore/mapper/extension/ShortTermRentalMapper.java
+++ b/backend/service-core/src/main/java/fi/hel/allu/servicecore/mapper/extension/ShortTermRentalMapper.java
@@ -9,6 +9,7 @@ public class ShortTermRentalMapper {
     shortTermRentalJson.setDescription(shortTermRental.getDescription());
     shortTermRentalJson.setCommercial(shortTermRental.getCommercial());
     shortTermRentalJson.setBillableSalesArea(shortTermRental.getBillableSalesArea());
+    shortTermRentalJson.setRegistrationNumbers(shortTermRental.getRegistrationNumbers());
     return ApplicationExtensionMapper.modelToJson(shortTermRental, shortTermRentalJson);
   }
 
@@ -17,6 +18,7 @@ public class ShortTermRentalMapper {
     shortTermRental.setDescription(json.getDescription());
     shortTermRental.setCommercial(json.getCommercial());
     shortTermRental.setBillableSalesArea(json.getBillableSalesArea());
+    shortTermRental.setRegistrationNumbers(json.getRegistrationNumbers());
     return ApplicationExtensionMapper.jsonToModel(json, shortTermRental);
   }
 }

--- a/backend/service-core/src/test/java/fi/hel/allu/servicecore/mapper/CustomerAnonymizerTest.java
+++ b/backend/service-core/src/test/java/fi/hel/allu/servicecore/mapper/CustomerAnonymizerTest.java
@@ -1,0 +1,108 @@
+package fi.hel.allu.servicecore.mapper;
+
+import fi.hel.allu.common.domain.types.CustomerType;
+import fi.hel.allu.servicecore.domain.CustomerJson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CustomerAnonymizerTest {
+
+  private CustomerAnonymizer anonymizer;
+
+  @BeforeEach
+  void setUp() {
+    anonymizer = new CustomerAnonymizer();
+  }
+
+  // --- sanitizeName ---
+
+  @Test
+  void sanitizeName_noSeparator_returnsUnchanged() {
+    assertEquals("Acme Oy", CustomerAnonymizer.sanitizeName("Acme Oy"));
+  }
+
+  @Test
+  void sanitizeName_null_returnsNull() {
+    assertNull(CustomerAnonymizer.sanitizeName(null));
+  }
+
+  @Test
+  void sanitizeName_emptyString_returnsEmpty() {
+    assertEquals("", CustomerAnonymizer.sanitizeName(""));
+  }
+
+  @ParameterizedTest(name = "[{index}] \"{0}\" → \"Acme Oy\"")
+  @CsvSource({
+      "Acme Oy; Toinen rivi",
+      "Acme Oy; Toinen rivi; Kolmas rivi",
+      "Acme Oy c/o Joku Henkilö",
+      "Acme Oy C/O Joku Henkilö",
+      "Acme Oy c/O Joku",
+      "Acme Oy C/o Joku",
+      "Acme Oy C / O Joku",
+      "Acme Oy c / o Joku",
+      "Acme Oy c / O Joku",
+      "Acme Oy C / o Joku",
+  })
+  void sanitizeName_withSeparator_returnsFirstPartTrimmed(String input) {
+    assertEquals("Acme Oy", CustomerAnonymizer.sanitizeName(input));
+  }
+
+  @Test
+  void sanitizeName_semicolonBeforeCO_truncatesAtSemicolon() {
+    // ';' comes first, so split happens there
+    assertEquals("Acme Oy", CustomerAnonymizer.sanitizeName("Acme Oy; C/O lisä"));
+  }
+
+  @Test
+  void sanitizeName_nameStartsWithCO_returnsEmpty() {
+    // "c/o Firma" — everything before c/o is empty string, trimmed → ""
+    assertEquals("", CustomerAnonymizer.sanitizeName("c/o Firma"));
+  }
+
+  // --- anonymizeCustomer ---
+
+  @Test
+  void anonymizeCustomer_personType_alwaysReturnsAnonymizedName() {
+    CustomerJson person = customerWithName("Matti Meikäläinen; rivi2", CustomerType.PERSON);
+    CustomerJson result = anonymizer.anonymizeCustomer(person);
+    assertEquals("Yksityishenkilö", result.getName());
+  }
+
+  @Test
+  void anonymizeCustomer_companyType_sanitizesName() {
+    CustomerJson company = customerWithName("Acme Oy; Toinen rivi", CustomerType.COMPANY);
+    CustomerJson result = anonymizer.anonymizeCustomer(company);
+    assertEquals("Acme Oy", result.getName());
+  }
+
+  @Test
+  void anonymizeCustomer_companyWithCO_sanitizesName() {
+    CustomerJson company = customerWithName("Kuljetusliike Oy C / O Vastaanottaja", CustomerType.COMPANY);
+    CustomerJson result = anonymizer.anonymizeCustomer(company);
+    assertEquals("Kuljetusliike Oy", result.getName());
+  }
+
+  @Test
+  void anonymizeCustomer_companyWithPlainName_nameUnchanged() {
+    CustomerJson company = customerWithName("Acme Oy", CustomerType.COMPANY);
+    CustomerJson result = anonymizer.anonymizeCustomer(company);
+    assertEquals("Acme Oy", result.getName());
+  }
+
+  // --- helper ---
+
+  private CustomerJson customerWithName(String name, CustomerType type) {
+    CustomerJson customer = new CustomerJson();
+    customer.setName(name);
+    customer.setType(type);
+    return customer;
+  }
+}
+

--- a/backend/service-core/src/test/java/fi/hel/allu/servicecore/mapper/CustomerAnonymizerTest.java
+++ b/backend/service-core/src/test/java/fi/hel/allu/servicecore/mapper/CustomerAnonymizerTest.java
@@ -96,6 +96,32 @@ class CustomerAnonymizerTest {
     assertEquals("Acme Oy", result.getName());
   }
 
+  // --- registryKey removal ---
+
+  @Test
+  void anonymizeCustomer_companyType_registryKeyIsNull() {
+    CustomerJson company = customerWithName("Acme Oy", CustomerType.COMPANY);
+    company.setRegistryKey("1234567-8");
+    CustomerJson result = anonymizer.anonymizeCustomer(company);
+    assertNull(result.getRegistryKey());
+  }
+
+  @Test
+  void anonymizeCustomer_associationType_registryKeyIsNull() {
+    CustomerJson association = customerWithName("Testi ry", CustomerType.ASSOCIATION);
+    association.setRegistryKey("1234567-8");
+    CustomerJson result = anonymizer.anonymizeCustomer(association);
+    assertNull(result.getRegistryKey());
+  }
+
+  @Test
+  void anonymizeCustomer_personType_registryKeyIsNull() {
+    CustomerJson person = customerWithName("Matti Meikäläinen", CustomerType.PERSON);
+    person.setRegistryKey("010188-012C");
+    CustomerJson result = anonymizer.anonymizeCustomer(person);
+    assertNull(result.getRegistryKey());
+  }
+
   // --- helper ---
 
   private CustomerJson customerWithName(String name, CustomerType type) {

--- a/backend/service-core/src/test/java/fi/hel/allu/servicecore/mapper/DecisionJsonMapperShortTermRentalTest.java
+++ b/backend/service-core/src/test/java/fi/hel/allu/servicecore/mapper/DecisionJsonMapperShortTermRentalTest.java
@@ -1,0 +1,84 @@
+package fi.hel.allu.servicecore.mapper;
+
+import fi.hel.allu.common.domain.types.ApplicationKind;
+import fi.hel.allu.common.domain.types.ApplicationType;
+import fi.hel.allu.pdf.domain.DecisionJson;
+import fi.hel.allu.servicecore.domain.ApplicationJson;
+import fi.hel.allu.servicecore.domain.ShortTermRentalJson;
+import fi.hel.allu.servicecore.service.MetaService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+public class DecisionJsonMapperShortTermRentalTest {
+
+  private static final String REGISTRATION_NUMBERS = "AKU-123, LOL-1, AUD-1";
+
+  private DecisionJsonMapper mapper;
+
+  @Before
+  public void setup() {
+    MetaService metaService = Mockito.mock(MetaService.class);
+    when(metaService.findTranslation(anyString(), anyString())).thenReturn("Liikkuva myynti");
+    // All service dependencies can be null because the test application has no locations,
+    // no customers and no id – those code paths are skipped.
+    mapper = new DecisionJsonMapper(null, null, null, null, metaService);
+  }
+
+  @Test
+  public void shouldMapRegistrationNumbersToDecisionJson() {
+    ApplicationJson application = createStrApplication(REGISTRATION_NUMBERS);
+
+    DecisionJson result = mapper.mapToDocumentJson(application, false);
+
+    assertEquals(REGISTRATION_NUMBERS, result.getRegistrationNumbers());
+  }
+
+  @Test
+  public void shouldHandleNullRegistrationNumbers() {
+    ApplicationJson application = createStrApplication(null);
+
+    DecisionJson result = mapper.mapToDocumentJson(application, false);
+
+    assertNull(result.getRegistrationNumbers());
+  }
+
+  @Test
+  public void anonymizedDocumentMapperShouldStillWriteRegistrationNumbers() {
+    // Anonymization is enforced at XSL level via the anonymizedDocument flag,
+    // NOT by the mapper. The mapper always writes the field.
+    ApplicationJson application = createStrApplication(REGISTRATION_NUMBERS);
+
+    DecisionJson result = mapper.mapToDocumentJson(application, false);
+
+    assertEquals(REGISTRATION_NUMBERS, result.getRegistrationNumbers());
+  }
+
+  /**
+   * Creates a minimal SHORT_TERM_RENTAL ApplicationJson with the given registrationNumbers.
+   * Locations and customer contacts are intentionally empty to keep service mocking minimal.
+   */
+  private ApplicationJson createStrApplication(String registrationNumbers) {
+    ApplicationJson application = new ApplicationJson();
+    application.setType(ApplicationType.SHORT_TERM_RENTAL);
+    application.setKindsWithSpecifiers(
+        Collections.singletonMap(ApplicationKind.MOBILE_SALES, Collections.emptyList()));
+    application.setLocations(Collections.emptyList());
+    application.setCustomersWithContacts(Collections.emptyList());
+
+    ShortTermRentalJson extension = new ShortTermRentalJson();
+    extension.setDescription("Testikuvaus");
+    extension.setRegistrationNumbers(registrationNumbers);
+    application.setExtension(extension);
+
+    return application;
+  }
+}
+

--- a/backend/service-core/src/test/java/fi/hel/allu/servicecore/mapper/extension/ShortTermRentalMapperTest.java
+++ b/backend/service-core/src/test/java/fi/hel/allu/servicecore/mapper/extension/ShortTermRentalMapperTest.java
@@ -1,0 +1,105 @@
+package fi.hel.allu.servicecore.mapper.extension;
+
+import fi.hel.allu.model.domain.ShortTermRental;
+import fi.hel.allu.servicecore.domain.ShortTermRentalJson;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ShortTermRentalMapperTest {
+
+  private static final String DESCRIPTION = "Vuokrauksen kuvaus";
+  private static final Boolean COMMERCIAL = true;
+  private static final Boolean BILLABLE_SALES_AREA = false;
+  private static final String REGISTRATION_NUMBERS = "ABC-123\nXYZ-456";
+
+  @Test
+  public void modelToJson_shouldMapRegistrationNumbers() {
+    ShortTermRental model = createModel(REGISTRATION_NUMBERS);
+
+    ShortTermRentalJson json = ShortTermRentalMapper.modelToJson(model);
+
+    assertEquals(REGISTRATION_NUMBERS, json.getRegistrationNumbers());
+  }
+
+  @Test
+  public void modelToJson_shouldMapAllFields() {
+    ShortTermRental model = createModel(REGISTRATION_NUMBERS);
+
+    ShortTermRentalJson json = ShortTermRentalMapper.modelToJson(model);
+
+    assertEquals(DESCRIPTION, json.getDescription());
+    assertEquals(COMMERCIAL, json.getCommercial());
+    assertEquals(BILLABLE_SALES_AREA, json.getBillableSalesArea());
+    assertEquals(REGISTRATION_NUMBERS, json.getRegistrationNumbers());
+  }
+
+  @Test
+  public void modelToJson_shouldHandleNullRegistrationNumbers() {
+    ShortTermRental model = createModel(null);
+
+    ShortTermRentalJson json = ShortTermRentalMapper.modelToJson(model);
+
+    assertNull(json.getRegistrationNumbers());
+  }
+
+  @Test
+  public void jsonToModel_shouldMapRegistrationNumbers() {
+    ShortTermRentalJson json = createJson(REGISTRATION_NUMBERS);
+
+    ShortTermRental model = ShortTermRentalMapper.jsonToModel(json);
+
+    assertEquals(REGISTRATION_NUMBERS, model.getRegistrationNumbers());
+  }
+
+  @Test
+  public void jsonToModel_shouldMapAllFields() {
+    ShortTermRentalJson json = createJson(REGISTRATION_NUMBERS);
+
+    ShortTermRental model = ShortTermRentalMapper.jsonToModel(json);
+
+    assertEquals(DESCRIPTION, model.getDescription());
+    assertEquals(COMMERCIAL, model.getCommercial());
+    assertEquals(BILLABLE_SALES_AREA, model.getBillableSalesArea());
+    assertEquals(REGISTRATION_NUMBERS, model.getRegistrationNumbers());
+  }
+
+  @Test
+  public void jsonToModel_shouldHandleNullRegistrationNumbers() {
+    ShortTermRentalJson json = createJson(null);
+
+    ShortTermRental model = ShortTermRentalMapper.jsonToModel(json);
+
+    assertNull(model.getRegistrationNumbers());
+  }
+
+  @Test
+  public void roundTrip_modelToJsonToModel_preservesRegistrationNumbers() {
+    ShortTermRental original = createModel(REGISTRATION_NUMBERS);
+
+    ShortTermRentalJson json = ShortTermRentalMapper.modelToJson(original);
+    ShortTermRental roundTripped = ShortTermRentalMapper.jsonToModel(json);
+
+    assertEquals(original.getRegistrationNumbers(), roundTripped.getRegistrationNumbers());
+  }
+
+  private ShortTermRental createModel(String registrationNumbers) {
+    ShortTermRental model = new ShortTermRental();
+    model.setDescription(DESCRIPTION);
+    model.setCommercial(COMMERCIAL);
+    model.setBillableSalesArea(BILLABLE_SALES_AREA);
+    model.setRegistrationNumbers(registrationNumbers);
+    return model;
+  }
+
+  private ShortTermRentalJson createJson(String registrationNumbers) {
+    ShortTermRentalJson json = new ShortTermRentalJson();
+    json.setDescription(DESCRIPTION);
+    json.setCommercial(COMMERCIAL);
+    json.setBillableSalesArea(BILLABLE_SALES_AREA);
+    json.setRegistrationNumbers(registrationNumbers);
+    return json;
+  }
+}
+

--- a/frontend/src/app/feature/application/info/short-term-rental/short-term-rental.component.html
+++ b/frontend/src/app/feature/application/info/short-term-rental/short-term-rental.component.html
@@ -110,6 +110,15 @@
               </mat-slide-toggle>
             </div>
           </div>
+          <div fxLayout="row" *ngIf="showRegistrationNumbers">
+            <div fxFlex>
+              <mat-form-field class="input-full-width">
+                <textarea matInput cdkTextareaAutosize formControlName="registrationNumbers"
+                          [placeholder]="'application.shortTermRental.registrationNumbers' | translation"
+                          [readonly]="readonly"></textarea>
+              </mat-form-field>
+            </div>
+          </div>
         </mat-card-content>
       </allu-card>
     </div>

--- a/frontend/src/app/feature/application/info/short-term-rental/short-term-rental.component.ts
+++ b/frontend/src/app/feature/application/info/short-term-rental/short-term-rental.component.ts
@@ -38,6 +38,16 @@ const kindsWithRecurring = [
   ApplicationKind.WINTER_TERRACE,
   ApplicationKind.PARKLET
 ];
+const kindsWithRegistrationNumbers = [
+  ApplicationKind.BENJI,
+  ApplicationKind.SUMMER_THEATER,
+  ApplicationKind.MOBILE_SALES,
+  ApplicationKind.OTHER,
+  ApplicationKind.SMALL_ART_AND_CULTURE,
+  ApplicationKind.SEASON_SALE,
+  ApplicationKind.CIRCUS,
+  ApplicationKind.ART
+];
 
 @Component({
   selector: 'short-term-rental',
@@ -50,6 +60,7 @@ export class ShortTermRentalComponent extends ApplicationInfoBaseComponent imple
   showCommercial = false;
   commercialLabel: string;
   recurringAllowed = false;
+  showRegistrationNumbers = false;
   dateFilter: DateFilter;
   kind$: Observable<ApplicationKind>;
   maxEndDate$: Observable<Date>;
@@ -131,6 +142,7 @@ export class ShortTermRentalComponent extends ApplicationInfoBaseComponent imple
     this.showCommercial = application.kinds.some(kind => ApplicationKind.BRIDGE_BANNER === kind);
     this.updateCommercialLabel(rental.commercial);
     this.recurringAllowed = kindsWithRecurring.indexOf(application.kind) >= 0;
+    this.showRegistrationNumbers = application.kinds.some(kind => kindsWithRegistrationNumbers.includes(kind));
   }
 
   protected update(form: ShortTermRentalForm): Application {

--- a/frontend/src/app/feature/application/info/short-term-rental/short-term-rental.form.ts
+++ b/frontend/src/app/feature/application/info/short-term-rental/short-term-rental.form.ts
@@ -13,6 +13,7 @@ export interface ShortTermRentalForm extends ApplicationForm {
   billableSalesArea?: boolean;
   terms?: string;
   recurringEndYear?: number;
+  registrationNumbers?: string;
 }
 
 export function from(application: Application, rental: ShortTermRental): ShortTermRentalForm {
@@ -23,7 +24,8 @@ export function from(application: Application, rental: ShortTermRental): ShortTe
     commercial: rental.commercial,
     billableSalesArea: rental.billableSalesArea,
     terms: rental.terms,
-    recurringEndYear: TimeUtil.yearFromDate(application.recurringEndTime)
+    recurringEndYear: TimeUtil.yearFromDate(application.recurringEndTime),
+    registrationNumbers: rental.registrationNumbers
   };
 }
 
@@ -33,6 +35,7 @@ export function to(form: ShortTermRentalForm): ShortTermRental {
   rental.commercial = form.commercial;
   rental.billableSalesArea = form.billableSalesArea;
   rental.terms = form.terms;
+  rental.registrationNumbers = form.registrationNumbers;
   return rental;
 }
 
@@ -47,7 +50,8 @@ export function createStructure(fb: UntypedFormBuilder): { [key: string]: any; }
       endTime: [undefined, Validators.required]
     }, { validator: ComplexValidator.startBeforeEnd('startTime', 'endTime') }),
     terms: [undefined],
-    recurringEndYear: [undefined, ComplexValidator.betweenOrEmpty(MIN_YEAR, MAX_YEAR)]
+    recurringEndYear: [undefined, ComplexValidator.betweenOrEmpty(MIN_YEAR, MAX_YEAR)],
+    registrationNumbers: ['']
   };
 }
 
@@ -58,5 +62,6 @@ export function createDraftStructure(fb: UntypedFormBuilder): { [key: string]: a
     startTime: [undefined, Validators.required],
     endTime: [undefined, Validators.required]
   }, { validator: ComplexValidator.startBeforeEnd('startTime', 'endTime') });
+  form.registrationNumbers = [''];
   return form;
 }

--- a/frontend/src/app/model/application/short-term-rental/short-term-rental.ts
+++ b/frontend/src/app/model/application/short-term-rental/short-term-rental.ts
@@ -6,7 +6,8 @@ export class ShortTermRental extends ApplicationExtension {
     public description?: string,
     public commercial?: boolean,
     public billableSalesArea?: boolean,
-    public terms?: string) {
+    public terms?: string,
+    public registrationNumbers?: string) {
     super(ApplicationType[ApplicationType.SHORT_TERM_RENTAL], terms);
   }
 }

--- a/frontend/src/app/service/mapper/application-extension-mapper.ts
+++ b/frontend/src/app/service/mapper/application-extension-mapper.ts
@@ -43,7 +43,8 @@ export class ApplicationExtensionMapper {
           backendExtension.description,
           backendExtension.commercial,
           backendExtension.billableSalesArea,
-          backendExtension.terms);
+          backendExtension.terms,
+          backendExtension.registrationNumbers);
       case ApplicationType.CABLE_REPORT:
         return new CableReport(
           TimeUtil.dateFromBackend(backendExtension.validityTime),
@@ -175,7 +176,8 @@ export class ApplicationExtensionMapper {
       description: rental.description,
       commercial: rental.commercial,
       billableSalesArea: rental.billableSalesArea,
-      terms: rental.terms
+      terms: rental.terms,
+      registrationNumbers: rental.registrationNumbers
     };
   }
 

--- a/frontend/src/app/util/translations.ts
+++ b/frontend/src/app/util/translations.ts
@@ -400,6 +400,7 @@ export const translations = {
       description: 'Vuokrauksen kuvaus',
       commercial: 'Kaupallinen',
       nonCommercial: 'Ei kaupallinen',
+      registrationNumbers: 'Rekisterinumerot',
       field: {
         descriptionMissing: 'Vuokrauksen kuvaus puuttuu',
         rentalStartTimeMissing: 'Vuokrauksen alkuaika puuttuu',

--- a/frontend/src/test/feature/application/info/short-term-rental/short-term-rental.form.spec.ts
+++ b/frontend/src/test/feature/application/info/short-term-rental/short-term-rental.form.spec.ts
@@ -1,0 +1,98 @@
+import {UntypedFormBuilder} from '@angular/forms';
+import {Application} from '@model/application/application';
+import {ShortTermRental} from '@model/application/short-term-rental/short-term-rental';
+import {from, to, createStructure, createDraftStructure} from '@feature/application/info/short-term-rental/short-term-rental.form';
+
+describe('short-term-rental.form', () => {
+  const REGISTRATION_NUMBERS = 'ABC-123\nXYZ-456';
+
+  function createApplication(): Application {
+    const app = new Application();
+    app.name = 'Test rental';
+    return app;
+  }
+
+  function createRental(registrationNumbers?: string): ShortTermRental {
+    const rental = new ShortTermRental();
+    rental.description = 'Kuvaus';
+    rental.commercial = false;
+    rental.billableSalesArea = true;
+    rental.registrationNumbers = registrationNumbers;
+    return rental;
+  }
+
+  describe('from()', () => {
+    it('should map registrationNumbers from rental to form', () => {
+      const rental = createRental(REGISTRATION_NUMBERS);
+      const result = from(createApplication(), rental);
+      expect(result.registrationNumbers).toBe(REGISTRATION_NUMBERS);
+    });
+
+    it('should map undefined registrationNumbers as undefined', () => {
+      const rental = createRental(undefined);
+      const result = from(createApplication(), rental);
+      expect(result.registrationNumbers).toBeUndefined();
+    });
+
+    it('should map other fields alongside registrationNumbers', () => {
+      const rental = createRental(REGISTRATION_NUMBERS);
+      const result = from(createApplication(), rental);
+      expect(result.description).toBe(rental.description);
+      expect(result.commercial).toBe(rental.commercial);
+      expect(result.billableSalesArea).toBe(rental.billableSalesArea);
+      expect(result.registrationNumbers).toBe(REGISTRATION_NUMBERS);
+    });
+  });
+
+  describe('to()', () => {
+    it('should map registrationNumbers from form to rental', () => {
+      const formValue = {registrationNumbers: REGISTRATION_NUMBERS};
+      const result = to(formValue);
+      expect(result.registrationNumbers).toBe(REGISTRATION_NUMBERS);
+    });
+
+    it('should map undefined registrationNumbers from form to rental', () => {
+      const result = to({registrationNumbers: undefined});
+      expect(result.registrationNumbers).toBeUndefined();
+    });
+
+    it('should map other fields alongside registrationNumbers', () => {
+      const formValue = {
+        description: 'Kuvaus',
+        commercial: true,
+        billableSalesArea: false,
+        registrationNumbers: REGISTRATION_NUMBERS
+      };
+      const result = to(formValue);
+      expect(result.description).toBe('Kuvaus');
+      expect(result.commercial).toBe(true);
+      expect(result.billableSalesArea).toBe(false);
+      expect(result.registrationNumbers).toBe(REGISTRATION_NUMBERS);
+    });
+  });
+
+  describe('createStructure()', () => {
+    it('should include registrationNumbers control', () => {
+      const fb = new UntypedFormBuilder();
+      const structure = createStructure(fb);
+      expect(structure.registrationNumbers).toBeDefined();
+    });
+
+    it('should initialize registrationNumbers with empty string', () => {
+      const fb = new UntypedFormBuilder();
+      const structure = createStructure(fb);
+      const fb2 = new UntypedFormBuilder();
+      const group = fb2.group(structure);
+      expect(group.get('registrationNumbers').value).toBe('');
+    });
+  });
+
+  describe('createDraftStructure()', () => {
+    it('should include registrationNumbers control', () => {
+      const fb = new UntypedFormBuilder();
+      const structure = createDraftStructure(fb);
+      expect(structure.registrationNumbers).toBeDefined();
+    });
+  });
+});
+


### PR DESCRIPTION
Toteutus sisältää muutoksia julkaistaviin anonymisoitaviin päätöksiin ja lyhyeen maanvuokraukseen (uuden rekisterinumero-kentän lisääminen tietyille hakemuslajeille). Kts. commitit.

Tiketit 197, 198, 201 ja 202.

https://helsinkisolutionoffice.atlassian.net/browse/ALLU-197
https://helsinkisolutionoffice.atlassian.net/browse/ALLU-198
https://helsinkisolutionoffice.atlassian.net/browse/ALLU-201
https://helsinkisolutionoffice.atlassian.net/browse/ALLU-202