### PR TITLE
ALLU-219/207: Parannettu asiakkaiden poistoon liittyvää logiikkaa

### DIFF
--- a/backend/model-service/src/main/java/fi/hel/allu/model/controller/CustomerController.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/controller/CustomerController.java
@@ -189,16 +189,17 @@ public class CustomerController {
   /**
    * Returns a page of customer IDs that are eligible for permanent (hard) deletion by the scheduler.
    * Eligible customers are inactive (is_active = false) and have had no changes for at least 5 years.
+   * Uses cursor/keyset pagination: pass the last seen customer ID as {@code afterId}.
    *
    * @param pageSize number of IDs to return (default 500)
-   * @param offset   pagination offset (default 0)
+   * @param afterId  cursor: return only customers with id greater than this value (default 0 = first page)
    * @return list of purgeable customer IDs
    */
   @GetMapping("/purgeable")
   public ResponseEntity<List<Integer>> getPurgeableCustomerIds(
       @RequestParam(defaultValue = "500") int pageSize,
-      @RequestParam(defaultValue = "0") long offset) {
-    return ResponseEntity.ok(customerService.findPurgeableCustomerIds(pageSize, offset));
+      @RequestParam(defaultValue = "0") int afterId) {
+    return ResponseEntity.ok(customerService.findPurgeableCustomerIds(pageSize, afterId));
   }
 
   /**

--- a/backend/model-service/src/main/java/fi/hel/allu/model/dao/CustomerDao.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/dao/CustomerDao.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.querydsl.core.QueryException;
+import com.querydsl.core.QueryFlag;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
@@ -405,32 +406,26 @@ public class CustomerDao {
   /**
    * Finds customer IDs that are eligible for permanent (hard) deletion.
    * A customer is purgeable when ALL the following conditions are met:
-   * - Is_active = false (already soft-deleted; FK checks were done at soft-delete time
-   *   and a deactivated customer cannot be re-linked to any application or project)
-   * - SAP customers (sap_customer_number IS NOT NULL) must have notification_sent_at set,
-   *   meaning the removal email notification has been sent before permanent deletion
+   * - Is_active = false (already soft-deleted)
+   * - Not linked to any application, project, or as an invoice recipient
+   * - SAP customers (sap_customer_number IS NOT NULL) must have notification_sent_at set
    * - The data retention period of 5 years has elapsed since the most recent entry across
-   *   ALL history and audit log tables:
-   *     * change_history (change_time)
-   *     * customer_update_log (update_time)
-   *     * person_audit_log (creation_time) — checked for both the customer and its contacts
-   *   A customer is only purgeable when every one of these tables either has no rows for the
-   *   customer or its latest row is older than the retention cutoff.
+   *   ALL history and audit log tables
+   *
+   * Uses cursor/keyset pagination: returns up to {@code pageSize} IDs with id > {@code afterId},
+   * ordered by customer.id ASC. Pass the last seen ID as {@code afterId} for subsequent pages.
    *
    * @param pageSize  number of IDs to return
-   * @param offset    pagination offset
+   * @param afterId   cursor: only return customers with id greater than this value (pass 0 for first page)
    * @return list of customer IDs eligible for permanent deletion
    */
   @Transactional(readOnly = true)
-  public List<Integer> findPurgeableCustomerIds(int pageSize, long offset) {
+  public List<Integer> findPurgeableCustomerIds(int pageSize, int afterId) {
     ZonedDateTime retentionCutoff = ZonedDateTime.now().minusYears(5);
 
     // Subquery expressions for MAX() timestamps across the three log tables.
     // When a table has no rows for a given customer, MAX() returns NULL.
-    // In SQL, NULL < value evaluates to NULL (not TRUE), so the condition would never
-    // pass for customers with no rows in a given table.
-    // We therefore treat NULL (= no rows) as satisfying the retention condition:
-    //   "no rows at all" means there is nothing newer than the cutoff.
+    // We treat NULL (= no rows) as satisfying the retention condition.
     var maxChangeTime = SQLExpressions.select(changeHistory.changeTime.max())
       .from(changeHistory)
       .where(changeHistory.customerId.eq(customer.id));
@@ -457,18 +452,21 @@ public class CustomerDao {
       .from(customer)
       .where(
         customer.isActive.isFalse()
-          // change_history: either no rows for this customer, or latest entry older than cutoff
+          // Cursor-based pagination: only IDs greater than the last seen ID
+          .and(customer.id.gt(afterId))
+          // Entity-link guard: must not be linked to any application, project, or invoice recipient
+          .and(isNotLinkedToAnyEntity())
+          // change_history: either no rows for this customer or latest entry older than cutoff
           .and(maxChangeTime.isNull().or(maxChangeTime.lt(retentionCutoff)))
-          // customer_update_log: either no rows for this customer, or latest entry older than cutoff
+          // customer_update_log: either no rows for this customer or latest entry older than cutoff
           .and(maxUpdateTime.isNull().or(maxUpdateTime.lt(retentionCutoff)))
-          // person_audit_log: either no rows for this customer/contacts, or latest entry older than cutoff
+          // person_audit_log: either no rows for this customer/contacts or latest entry older than cutoff
           .and(maxAuditTime.isNull().or(maxAuditTime.lt(retentionCutoff)))
           // SAP customers must have had their removal notification sent before being permanently deleted
           .and(customer.sapCustomerNumber.isNull().or(customer.notificationSentAt.isNotNull()))
       )
       .orderBy(customer.id.asc())
       .limit(pageSize)
-      .offset(offset)
       .fetch();
   }
 
@@ -539,6 +537,7 @@ public class CustomerDao {
           .from(customer)
           .where(customer.id.in(ids))
       )
+      .addFlag(QueryFlag.Position.END, " ON CONFLICT (customer_id) DO NOTHING")
       .execute();
   }
 

--- a/backend/model-service/src/main/java/fi/hel/allu/model/dao/CustomerDao.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/dao/CustomerDao.java
@@ -346,6 +346,27 @@ public class CustomerDao {
   }
 
   private BooleanExpression isDeletableCustomer(Instant cutoff) {
+    BooleanExpression notRecentlyCreated = SQLExpressions.selectOne()
+      .from(changeHistory)
+      .where(
+        changeHistory.customerId.eq(customer.id),
+        changeHistory.changeType.eq(ChangeType.CREATED),
+        changeHistory.changeTime.gt(cutoff.atZone(ZoneOffset.UTC))
+      )
+      .notExists();
+
+    return customer.isActive.isTrue()
+      .and(isNotLinkedToAnyEntity())
+      .and(notRecentlyCreated);
+  }
+
+  /**
+   * Returns a combined BooleanExpression that is true when the customer is not linked to any
+   * application (via application_customer), not set as invoice recipient on any application,
+   * and not linked to any project. These three conditions are shared between
+   * {@link #isDeletableCustomer(Instant)} and {@link #findUnnotifiedSapCustomers()}.
+   */
+  private BooleanExpression isNotLinkedToAnyEntity() {
     BooleanExpression notLinkedToApplication = SQLExpressions.selectOne()
       .from(applicationCustomer)
       .where(applicationCustomer.customerId.eq(customer.id))
@@ -361,20 +382,7 @@ public class CustomerDao {
       .where(application.invoiceRecipientId.eq(customer.id))
       .notExists();
 
-    BooleanExpression notRecentlyCreated = SQLExpressions.selectOne()
-      .from(changeHistory)
-      .where(
-        changeHistory.customerId.eq(customer.id),
-        changeHistory.changeType.eq(ChangeType.CREATED),
-        changeHistory.changeTime.gt(cutoff.atZone(ZoneOffset.UTC))
-      )
-      .notExists();
-
-    return customer.isActive.isTrue()
-      .and(notLinkedToApplication)
-      .and(notLinkedToProject)
-      .and(notInvoiceRecipient)
-      .and(notRecentlyCreated);
+    return notLinkedToApplication.and(notLinkedToProject).and(notInvoiceRecipient);
   }
 
   private OrderSpecifier<?> toCustomerOrderSpecifier(Sort sort) {
@@ -583,8 +591,10 @@ public class CustomerDao {
 
   /**
    * Find 'removed' inactive SAP customers which have not been marked as notified (no email notification sent).
+   * Customers that are still linked to any application (via application_customer), set as invoice recipient
+   * on any application, or linked to any project are excluded from the result.
    *
-   * @return list of inactive SAP customers which have not been marked as notified.
+   * @return list of inactive, unnotified, and unlinked SAP customers.
    */
   @Transactional(readOnly = true)
   public List<CustomerSapInfo> findUnnotifiedSapCustomers() {
@@ -600,7 +610,8 @@ public class CustomerDao {
         .where(
           customer.sapCustomerNumber.isNotNull(),
           customer.notificationSentAt.isNull(),
-          customer.isActive.eq(false)
+          customer.isActive.eq(false),
+          isNotLinkedToAnyEntity()
         )
         .orderBy(customer.id.asc())
         .fetch();

--- a/backend/model-service/src/main/java/fi/hel/allu/model/service/CustomerService.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/service/CustomerService.java
@@ -365,7 +365,7 @@ public class CustomerService {
     List<CustomerSapInfo> customers = customerDao.findUnnotifiedSapCustomers();
 
     logger.info(
-      "Fetched {} 'removed' inactive unnotified SAP customers",
+      "Fetched {} inactive, unnotified, and unlinked SAP customers",
       customers.size()
     );
 
@@ -375,7 +375,7 @@ public class CustomerService {
   @Transactional
   public void markSapCustomersNotified(List<Integer> ids) {
     logger.info(
-      "Marking {} 'removed' inactive SAP customers as notified",
+      "Marking {} inactive SAP customers as notified",
       ids.size()
     );
 

--- a/backend/model-service/src/main/java/fi/hel/allu/model/service/CustomerService.java
+++ b/backend/model-service/src/main/java/fi/hel/allu/model/service/CustomerService.java
@@ -302,13 +302,13 @@ public class CustomerService {
    * Returns a page of customer IDs eligible for permanent deletion by the scheduler.
    *
    * @param pageSize number of IDs to return
-   * @param offset   pagination offset
+   * @param afterId  cursor: only return customers with id greater than this value (pass 0 for first page)
    * @return list of purgeable customer IDs
    */
   @Transactional(readOnly = true)
-  public List<Integer> findPurgeableCustomerIds(int pageSize, long offset) {
-    List<Integer> ids = customerDao.findPurgeableCustomerIds(pageSize, offset);
-    logger.debug("Found {} purgeable customer IDs (pageSize={}, offset={})", ids.size(), pageSize, offset);
+  public List<Integer> findPurgeableCustomerIds(int pageSize, int afterId) {
+    List<Integer> ids = customerDao.findPurgeableCustomerIds(pageSize, afterId);
+    logger.debug("Found {} purgeable customer IDs (pageSize={}, afterId={})", ids.size(), pageSize, afterId);
     return ids;
   }
 
@@ -405,6 +405,19 @@ public class CustomerService {
       return 0;
     }
     Set<Integer> idSet = new HashSet<>(ids);
+
+    // Runtime safety guard: remove any customers that are still linked to applications,
+    // projects, or are invoice recipients. This guards against race conditions where a
+    // customer becomes linked between the time findPurgeableCustomerIds ran and now.
+    List<Integer> nonPurgeableIds = customerDao.findNonDeletableCustomerIds(ids);
+    if (!nonPurgeableIds.isEmpty()) {
+      nonPurgeableIds.forEach(idSet::remove);
+      logger.warn("Skipping {} customers from purge because they are still linked to entities: {}",
+        nonPurgeableIds.size(), nonPurgeableIds);
+    }
+    if (idSet.isEmpty()) {
+      return 0;
+    }
 
     customerDao.archiveCustomers(idSet);
     logger.debug("Archived {} customers to customer_archive", idSet.size());

--- a/backend/model-service/src/main/resources/db/migration/V200__add_purge_performance_indexes.sql
+++ b/backend/model-service/src/main/resources/db/migration/V200__add_purge_performance_indexes.sql
@@ -1,0 +1,25 @@
+-- ALLU-207: Add composite covering indexes to speed up findPurgeableCustomerIds.
+-- Using CREATE INDEX CONCURRENTLY to avoid table-level locks on high-write tables.
+-- Note: single-column index change_history_customer_id_index already exists from V185;
+--       we add only the composite variant for that table.
+
+-- change_history: composite for MAX(change_time) per customer_id
+CREATE INDEX CONCURRENTLY change_history_customer_id_change_time_index
+  ON allu.change_history (customer_id, change_time);
+
+-- customer_update_log: missing index; needed for MAX(update_time) per customer_id
+CREATE INDEX CONCURRENTLY customer_update_log_customer_id_update_time_index
+  ON allu.customer_update_log (customer_id, update_time);
+
+-- person_audit_log: missing index for customer-level lookup
+CREATE INDEX CONCURRENTLY person_audit_log_customer_id_creation_time_index
+  ON allu.person_audit_log (customer_id, creation_time);
+
+-- person_audit_log: missing index for contact-level lookup (nested subquery)
+CREATE INDEX CONCURRENTLY person_audit_log_contact_id_creation_time_index
+  ON allu.person_audit_log (contact_id, creation_time);
+
+-- contact: needed for the IN subquery feeding person_audit_log (customer_id → contact IDs)
+CREATE INDEX CONCURRENTLY contact_customer_id_index
+  ON allu.contact (customer_id);
+

--- a/backend/model-service/src/main/resources/db/migration/V201__customer_archive_unique_customer_id.sql
+++ b/backend/model-service/src/main/resources/db/migration/V201__customer_archive_unique_customer_id.sql
@@ -1,0 +1,14 @@
+-- ALLU-207: Add UNIQUE constraint on customer_archive.customer_id.
+-- Required before archiveCustomers can use ON CONFLICT (customer_id) DO NOTHING.
+-- Step 1: Remove duplicate rows, keeping the row with the smallest id per customer_id.
+-- Step 2: Add the UNIQUE constraint.
+
+DELETE FROM allu.customer_archive
+WHERE id NOT IN (
+  SELECT MIN(id)
+  FROM allu.customer_archive
+  GROUP BY customer_id
+);
+
+ALTER TABLE allu.customer_archive
+  ADD CONSTRAINT customer_archive_customer_id_unique UNIQUE (customer_id);

--- a/backend/model-service/src/test/java/fi/hel/allu/model/dao/CustomerDaoSpec.java
+++ b/backend/model-service/src/test/java/fi/hel/allu/model/dao/CustomerDaoSpec.java
@@ -682,6 +682,119 @@ public class CustomerDaoSpec extends SpeccyTestBase {
 
           assertTrue(result.isEmpty());
         });
+
+        it("should exclude customer linked via application_customer", () -> {
+          Customer c = customerDao.insert(dummyCustomer(10));
+          c.setSapCustomerNumber("SAP10");
+          c.setIsActive(false);
+          customerDao.update(c.getId(), c);
+
+          Application app = testCommon.dummyOutdoorApplication("AppLink", RandomStringUtils.randomAlphabetic(10));
+          app.setCustomersWithContacts(
+            Collections.singletonList(
+              new CustomerWithContacts(CustomerRoleType.APPLICANT, c, Collections.emptyList())
+            )
+          );
+          applicationDao.insert(app);
+
+          List<CustomerSapInfo> result = customerDao.findUnnotifiedSapCustomers();
+
+          assertTrue("Linked customer must not appear in result",
+            result.stream().noneMatch(r -> "SAP10".equals(r.sapCustomerNumber())));
+        });
+
+        it("should exclude customer set as invoice recipient on an application", () -> {
+          Customer c = customerDao.insert(dummyCustomer(11));
+          c.setSapCustomerNumber("SAP11");
+          c.setIsActive(false);
+          customerDao.update(c.getId(), c);
+
+          Application invoiceApp = testCommon.dummyOutdoorApplication("InvoiceApp", RandomStringUtils.randomAlphabetic(10));
+          invoiceApp.setInvoiceRecipientId(c.getId());
+          applicationDao.insert(invoiceApp);
+
+          List<CustomerSapInfo> result = customerDao.findUnnotifiedSapCustomers();
+
+          assertTrue("Invoice recipient customer must not appear in result",
+            result.stream().noneMatch(r -> "SAP11".equals(r.sapCustomerNumber())));
+        });
+
+        it("should exclude customer linked to a project", () -> {
+          Customer c = customerDao.insert(dummyCustomer(12));
+          c.setSapCustomerNumber("SAP12");
+          c.setIsActive(false);
+          customerDao.update(c.getId(), c);
+
+          Project project = new Project();
+          project.setName("proj-sap");
+          project.setCustomerId(c.getId());
+          project.setContactId(testCommon.insertContact(c.getId()).getId());
+          project.setStartTime(ZonedDateTime.now());
+          project.setIdentifier("identifier-sap");
+          project.setCreatorId(testCommon.insertUser(RandomStringUtils.randomAlphabetic(10)).getId());
+          projectDao.insert(project);
+
+          List<CustomerSapInfo> result = customerDao.findUnnotifiedSapCustomers();
+
+          assertTrue("Project-linked customer must not appear in result",
+            result.stream().noneMatch(r -> "SAP12".equals(r.sapCustomerNumber())));
+        });
+
+        it("should exclude customer linked via all three link types only once (result size is correct)", () -> {
+          Customer linked = customerDao.insert(dummyCustomer(13));
+          linked.setSapCustomerNumber("SAP13");
+          linked.setIsActive(false);
+          customerDao.update(linked.getId(), linked);
+
+          // Link via application_customer
+          Application app = testCommon.dummyOutdoorApplication("TripleLink", RandomStringUtils.randomAlphabetic(10));
+          app.setCustomersWithContacts(
+            Collections.singletonList(
+              new CustomerWithContacts(CustomerRoleType.APPLICANT, linked, Collections.emptyList())
+            )
+          );
+          applicationDao.insert(app);
+
+          // Link via invoice_recipient_id
+          Application invoiceApp = testCommon.dummyOutdoorApplication("TripleLinkInvoice", RandomStringUtils.randomAlphabetic(10));
+          invoiceApp.setInvoiceRecipientId(linked.getId());
+          applicationDao.insert(invoiceApp);
+
+          // Link via project
+          Project project = new Project();
+          project.setName("proj-triple");
+          project.setCustomerId(linked.getId());
+          project.setContactId(testCommon.insertContact(linked.getId()).getId());
+          project.setStartTime(ZonedDateTime.now());
+          project.setIdentifier("identifier-triple");
+          project.setCreatorId(testCommon.insertUser(RandomStringUtils.randomAlphabetic(10)).getId());
+          projectDao.insert(project);
+
+          // An unlinked SAP customer that should still appear
+          Customer unlinked = customerDao.insert(dummyCustomer(14));
+          unlinked.setSapCustomerNumber("SAP14");
+          unlinked.setIsActive(false);
+          customerDao.update(unlinked.getId(), unlinked);
+
+          List<CustomerSapInfo> result = customerDao.findUnnotifiedSapCustomers();
+
+          assertTrue("Unlinked customer must appear",
+            result.stream().anyMatch(r -> "SAP14".equals(r.sapCustomerNumber())));
+          assertEquals("Triply-linked customer must appear only 0 extra times (excluded once)",
+            0L, result.stream().filter(r -> "SAP13".equals(r.sapCustomerNumber())).count());
+        });
+
+        it("should still return unlinked inactive SAP customer (regression)", () -> {
+          Customer c = customerDao.insert(dummyCustomer(15));
+          c.setSapCustomerNumber("SAP15");
+          c.setIsActive(false);
+          customerDao.update(c.getId(), c);
+
+          List<CustomerSapInfo> result = customerDao.findUnnotifiedSapCustomers();
+
+          assertTrue("Unlinked inactive SAP customer must be returned",
+            result.stream().anyMatch(r -> "SAP15".equals(r.sapCustomerNumber())));
+        });
       });
     });
 

--- a/backend/model-service/src/test/java/fi/hel/allu/model/dao/CustomerDaoSpec.java
+++ b/backend/model-service/src/test/java/fi/hel/allu/model/dao/CustomerDaoSpec.java
@@ -5,6 +5,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import com.querydsl.sql.SQLQueryFactory;
 import fi.hel.allu.common.types.ChangeType;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.runner.RunWith;
@@ -26,6 +27,7 @@ import fi.hel.allu.model.testUtils.SpeccyTestBase;
 import fi.hel.allu.model.testUtils.TestCommon;
 
 import static com.greghaskins.spectrum.dsl.specification.Specification.*;
+import static fi.hel.allu.QCustomerArchive.customerArchive;
 import static org.junit.Assert.*;
 
 @RunWith(Spectrum.class)
@@ -47,6 +49,8 @@ public class CustomerDaoSpec extends SpeccyTestBase {
   CustomerUpdateLogDao customerUpdateLogDao;
   @Autowired
   PersonAuditLogDao personAuditLogDao;
+  @Autowired
+  SQLQueryFactory sqlQueryFactory;
   @Autowired
   TestCommon testCommon;
 
@@ -468,7 +472,7 @@ public class CustomerDaoSpec extends SpeccyTestBase {
           assertFalse("Customer with recent person_audit_log (contact) must not be purgeable", ids.contains(c.getId()));
         });
 
-        it("should support pagination via pageSize and offset", () -> {
+        it("should support cursor-based pagination via pageSize and afterId", () -> {
           ZonedDateTime overFiveYearsAgo = ZonedDateTime.now().minusYears(6);
           int userId = testCommon.insertUser(RandomStringUtils.randomAlphabetic(10)).getId();
 
@@ -484,10 +488,12 @@ public class CustomerDaoSpec extends SpeccyTestBase {
             historyDao.addCustomerChange(c.getId(), old);
           }
 
+          // First page: afterId=0, pageSize=2 → first 2 IDs
           List<Integer> firstPage = customerDao.findPurgeableCustomerIds(2, 0);
-          List<Integer> secondPage = customerDao.findPurgeableCustomerIds(2, 2);
-
           assertEquals(2, firstPage.size());
+
+          // Second page: afterId = last ID of first page → next 2 IDs
+          List<Integer> secondPage = customerDao.findPurgeableCustomerIds(2, firstPage.get(firstPage.size() - 1));
           assertEquals(2, secondPage.size());
           // Pages must not overlap
           firstPage.forEach(id -> assertFalse("Pages must not overlap", secondPage.contains(id)));
@@ -862,6 +868,177 @@ public class CustomerDaoSpec extends SpeccyTestBase {
           assertTrue(prevId < id);
           prevId = id;
         }
+      });
+    });
+
+    describe("CustomerDao.findPurgeableCustomerIds", () -> {
+
+      // Helper: creates and soft-deletes a customer with change_history older than 5 years
+      // so it qualifies as purgeable (when not linked to any entity).
+      beforeEach(() -> testCommon.deleteAllData());
+
+      it("should return an inactive customer whose log entries are older than 5 years and is not linked to any entity", () -> {
+        ZonedDateTime sixYearsAgo = ZonedDateTime.now().minusYears(6);
+        int userId = testCommon.insertUser(RandomStringUtils.randomAlphabetic(10)).getId();
+
+        Customer c = customerDao.insert(dummyCustomer(5000));
+        c.setIsActive(false);
+        customerDao.update(c.getId(), c);
+        ChangeHistoryItem old = new ChangeHistoryItem();
+        old.setUserId(userId);
+        old.setChangeType(ChangeType.CONTENTS_CHANGED);
+        old.setChangeTime(sixYearsAgo);
+        historyDao.addCustomerChange(c.getId(), old);
+
+        List<Integer> ids = customerDao.findPurgeableCustomerIds(10, 0);
+        assertTrue("Unlinked inactive customer with old history must be purgeable", ids.contains(c.getId()));
+      });
+
+      it("should exclude a customer linked via application_customer", () -> {
+        ZonedDateTime sixYearsAgo = ZonedDateTime.now().minusYears(6);
+        int userId = testCommon.insertUser(RandomStringUtils.randomAlphabetic(10)).getId();
+
+        Customer c = customerDao.insert(dummyCustomer(5001));
+        c.setIsActive(false);
+        customerDao.update(c.getId(), c);
+        ChangeHistoryItem old = new ChangeHistoryItem();
+        old.setUserId(userId);
+        old.setChangeType(ChangeType.CONTENTS_CHANGED);
+        old.setChangeTime(sixYearsAgo);
+        historyDao.addCustomerChange(c.getId(), old);
+
+        // Link via application_customer
+        Application app = testCommon.dummyOutdoorApplication("AppLink5001", RandomStringUtils.randomAlphabetic(10));
+        app.setCustomersWithContacts(
+          Collections.singletonList(
+            new CustomerWithContacts(CustomerRoleType.APPLICANT, c, Collections.emptyList())
+          )
+        );
+        applicationDao.insert(app);
+
+        List<Integer> ids = customerDao.findPurgeableCustomerIds(10, 0);
+        assertFalse("Customer linked via application_customer must not be purgeable", ids.contains(c.getId()));
+      });
+
+      it("should exclude a customer set as invoice recipient on an application", () -> {
+        ZonedDateTime sixYearsAgo = ZonedDateTime.now().minusYears(6);
+        int userId = testCommon.insertUser(RandomStringUtils.randomAlphabetic(10)).getId();
+
+        Customer c = customerDao.insert(dummyCustomer(5002));
+        c.setIsActive(false);
+        customerDao.update(c.getId(), c);
+        ChangeHistoryItem old = new ChangeHistoryItem();
+        old.setUserId(userId);
+        old.setChangeType(ChangeType.CONTENTS_CHANGED);
+        old.setChangeTime(sixYearsAgo);
+        historyDao.addCustomerChange(c.getId(), old);
+
+        Application invoiceApp = testCommon.dummyOutdoorApplication("InvoiceApp5002", RandomStringUtils.randomAlphabetic(10));
+        invoiceApp.setInvoiceRecipientId(c.getId());
+        applicationDao.insert(invoiceApp);
+
+        List<Integer> ids = customerDao.findPurgeableCustomerIds(10, 0);
+        assertFalse("Invoice recipient customer must not be purgeable", ids.contains(c.getId()));
+      });
+
+      it("should exclude a customer linked to a project", () -> {
+        ZonedDateTime sixYearsAgo = ZonedDateTime.now().minusYears(6);
+        int userId = testCommon.insertUser(RandomStringUtils.randomAlphabetic(10)).getId();
+
+        Customer c = customerDao.insert(dummyCustomer(5003));
+        c.setIsActive(false);
+        customerDao.update(c.getId(), c);
+        ChangeHistoryItem old = new ChangeHistoryItem();
+        old.setUserId(userId);
+        old.setChangeType(ChangeType.CONTENTS_CHANGED);
+        old.setChangeTime(sixYearsAgo);
+        historyDao.addCustomerChange(c.getId(), old);
+
+        Project project = new Project();
+        project.setName("proj-5003");
+        project.setCustomerId(c.getId());
+        project.setContactId(testCommon.insertContact(c.getId()).getId());
+        project.setStartTime(ZonedDateTime.now());
+        project.setIdentifier("identifier-5003");
+        project.setCreatorId(userId);
+        projectDao.insert(project);
+
+        List<Integer> ids = customerDao.findPurgeableCustomerIds(10, 0);
+        assertFalse("Project-linked customer must not be purgeable", ids.contains(c.getId()));
+      });
+
+      it("should exclude an active customer", () -> {
+        ZonedDateTime sixYearsAgo = ZonedDateTime.now().minusYears(6);
+        int userId = testCommon.insertUser(RandomStringUtils.randomAlphabetic(10)).getId();
+
+        Customer active = customerDao.insert(dummyCustomer(5004)); // isActive=true by default
+        ChangeHistoryItem old = new ChangeHistoryItem();
+        old.setUserId(userId);
+        old.setChangeType(ChangeType.CONTENTS_CHANGED);
+        old.setChangeTime(sixYearsAgo);
+        historyDao.addCustomerChange(active.getId(), old);
+
+        List<Integer> ids = customerDao.findPurgeableCustomerIds(10, 0);
+        assertFalse("Active customer must not be purgeable", ids.contains(active.getId()));
+      });
+
+      it("should exclude a customer whose most recent change_history entry is within 5 years", () -> {
+        int userId = testCommon.insertUser(RandomStringUtils.randomAlphabetic(10)).getId();
+
+        Customer c = customerDao.insert(dummyCustomer(5005));
+        c.setIsActive(false);
+        customerDao.update(c.getId(), c);
+        ChangeHistoryItem recent = new ChangeHistoryItem();
+        recent.setUserId(userId);
+        recent.setChangeType(ChangeType.CONTENTS_CHANGED);
+        recent.setChangeTime(ZonedDateTime.now().minusYears(1)); // within retention period
+        historyDao.addCustomerChange(c.getId(), recent);
+
+        List<Integer> ids = customerDao.findPurgeableCustomerIds(10, 0);
+        assertFalse("Customer with recent change_history must not be purgeable", ids.contains(c.getId()));
+      });
+    });
+
+    describe("CustomerDao.archiveCustomers", () -> {
+
+      beforeEach(() -> testCommon.deleteAllData());
+
+      it("should archive a customer and record sap_customer_number", () -> {
+        Customer c = customerDao.insert(dummyCustomer(6000));
+        c.setSapCustomerNumber("SAP-6000");
+        customerDao.update(c.getId(), c);
+
+        customerDao.archiveCustomers(Set.of(c.getId()));
+
+        // Query customer_archive directly for the customer_id
+        Long count = sqlQueryFactory
+          .select(customerArchive.customerId.count())
+          .from(customerArchive)
+          .where(customerArchive.customerId.eq(c.getId()))
+          .fetchOne();
+        assertEquals("Exactly one archive row must exist", 1L, (long) count);
+
+        String sapNumber = sqlQueryFactory
+          .select(customerArchive.sapCustomerNumber)
+          .from(customerArchive)
+          .where(customerArchive.customerId.eq(c.getId()))
+          .fetchOne();
+        assertEquals("SAP-6000", sapNumber);
+      });
+
+      it("should not create a duplicate row when archiving an already-archived customer", () -> {
+        Customer c = customerDao.insert(dummyCustomer(6001));
+
+        // Archive twice — ON CONFLICT DO NOTHING must prevent duplicate
+        customerDao.archiveCustomers(Set.of(c.getId()));
+        customerDao.archiveCustomers(Set.of(c.getId()));
+
+        Long count = sqlQueryFactory
+          .select(customerArchive.customerId.count())
+          .from(customerArchive)
+          .where(customerArchive.customerId.eq(c.getId()))
+          .fetchOne();
+        assertEquals("Duplicate archiveCustomers call must not create a second row", 1L, (long) count);
       });
     });
 

--- a/backend/model-service/src/test/java/fi/hel/allu/model/service/CustomerServiceSpec.java
+++ b/backend/model-service/src/test/java/fi/hel/allu/model/service/CustomerServiceSpec.java
@@ -220,6 +220,62 @@ public class CustomerServiceSpec extends SpeccyTestBase {
       }); // Find by multiple IDs
 
     }); // Contact operations
+
+    describe("purgeCustomersAndRelatedData", () -> {
+
+      beforeEach(() -> {
+        // Default: findDeletableContactIdsByCustomerIds returns empty list to avoid NPEs
+        Mockito.when(contactDao.findDeletableContactIdsByCustomerIds(Mockito.any()))
+          .thenReturn(Collections.emptyList());
+      });
+
+      it("should archive and delete customers that are not linked to any entity", () -> {
+        Mockito.when(customerDao.findNonDeletableCustomerIds(Mockito.anyList()))
+          .thenReturn(Collections.emptyList());
+        Mockito.when(customerDao.deleteCustomers(Mockito.any())).thenReturn(1L);
+
+        customerService.purgeCustomersAndRelatedData(List.of(42));
+
+        Mockito.verify(customerDao, Mockito.times(1)).archiveCustomers(Mockito.any());
+        Mockito.verify(customerDao, Mockito.times(1)).deleteCustomers(Mockito.any());
+      });
+
+      it("should skip customers that are linked and not call delete for them", () -> {
+        Mockito.when(customerDao.findNonDeletableCustomerIds(List.of(1, 2, 3)))
+          .thenReturn(List.of(2));
+        Mockito.when(customerDao.deleteCustomers(Mockito.any())).thenReturn(2L);
+
+        customerService.purgeCustomersAndRelatedData(List.of(1, 2, 3));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Set<Integer>> captor = ArgumentCaptor.forClass(Set.class);
+        Mockito.verify(customerDao).deleteCustomers(captor.capture());
+        Set<Integer> deletedIds = captor.getValue();
+        assertTrue("ID 1 must be deleted", deletedIds.contains(1));
+        assertTrue("ID 3 must be deleted", deletedIds.contains(3));
+        assertTrue("ID 2 (linked) must NOT be deleted", !deletedIds.contains(2));
+      });
+
+      it("should return 0 and not call any deletion method when all customers are linked", () -> {
+        Mockito.when(customerDao.findNonDeletableCustomerIds(List.of(5, 6)))
+          .thenReturn(List.of(5, 6));
+
+        int result = customerService.purgeCustomersAndRelatedData(List.of(5, 6));
+
+        assertEquals(0, result);
+        Mockito.verify(customerDao, Mockito.never()).archiveCustomers(Mockito.any());
+        Mockito.verify(customerDao, Mockito.never()).deleteCustomers(Mockito.any());
+      });
+
+      it("should return 0 immediately for an empty id list", () -> {
+        int result = customerService.purgeCustomersAndRelatedData(Collections.emptyList());
+
+        assertEquals(0, result);
+        Mockito.verify(customerDao, Mockito.never()).archiveCustomers(Mockito.any());
+        Mockito.verify(customerDao, Mockito.never()).deleteCustomers(Mockito.any());
+      });
+
+    });
   }
 
   private Customer dummyCustomer(int id) {

--- a/backend/scheduler-service/src/main/java/fi/hel/allu/scheduler/service/CustomerPurgeService.java
+++ b/backend/scheduler-service/src/main/java/fi/hel/allu/scheduler/service/CustomerPurgeService.java
@@ -8,6 +8,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -19,10 +20,11 @@ import java.util.List;
  * Service for permanently deleting inactive customers whose data retention period (5 years) has elapsed.
  *
  * The process:
- * 1. Fetch purgeable customer IDs page by page from model-service
+ * 1. Fetch purgeable customer IDs page by page from model-service (cursor-based pagination)
  * 2. Split IDs into batches of BATCH_SIZE
  * 3. For each batch, call DELETE /customers/purge — failures are caught, logged, and skipped
- * 4. Log a summary of the run
+ * 4. Abort early if the failure rate exceeds 20% (indicates a systemic problem)
+ * 5. Log a structured summary of the run
  */
 @Service
 public class CustomerPurgeService {
@@ -48,7 +50,8 @@ public class CustomerPurgeService {
 
   /**
    * Fetches all purgeable customer IDs and permanently deletes them in batches.
-   * A failure in one batch does not prevent later batches from being processed.
+   * A failure in one batch does not prevent later batches from being processed
+   * unless the failure rate exceeds 20% of the total attempted, which triggers an early abort.
    */
   public void purgeObsoleteCustomers() {
     logger.info("Customer purge job started");
@@ -60,7 +63,8 @@ public class CustomerPurgeService {
       return;
     }
 
-    logger.info("Found {} customers eligible for permanent deletion", allIds.size());
+    int totalEligible = allIds.size();
+    logger.info("Found {} customers eligible for permanent deletion", totalEligible);
 
     int successCount = 0;
     int failedCount = 0;
@@ -73,37 +77,71 @@ public class CustomerPurgeService {
         logger.debug("Purged batch of {} customers ({} confirmed deleted)", batch.size(), deleted);
       } catch (Exception e) {
         failedCount += batch.size();
-        logger.error("Failed to purge batch of {} customer IDs {}: {}", batch.size(), batch, e.getMessage());
+        String errorDetail;
+        try {
+          errorDetail = e.getMessage();
+          if (e instanceof HttpStatusCodeException httpEx) {
+            errorDetail += " | Response body: " + httpEx.getResponseBodyAsString();
+          }
+        } catch (Exception ignored) {
+          errorDetail = "(error extracting exception message)";
+        }
+        logger.error("Failed to purge batch of {} customer IDs {}: {}", batch.size(), batch, errorDetail);
+
+        // Failure-rate abort: if more than 20% of attempted customers have failed,
+        // this signals a systemic problem rather than isolated data issues.
+        int totalAttempted = successCount + failedCount;
+        if (failedCount > 0 && (double) failedCount / totalAttempted >= 0.20) {
+          logger.error(
+            "Purge abort: failure rate exceeded threshold ({}/{} = {}%). Remaining batches will not be attempted.",
+            failedCount, totalAttempted, (int) ((double) failedCount / totalAttempted * 100)
+          );
+          break;
+        }
       }
     }
 
-    logger.info("Customer purge job finished. Successfully deleted: {}, Failed: {}", successCount, failedCount);
+    logger.info("Customer purge job finished. Total eligible: {}, Successfully deleted: {}, Failed: {}",
+      totalEligible, successCount, failedCount);
   }
 
   /**
-   * Fetches all purgeable customer IDs by paginating through the model-service endpoint.
+   * Fetches all purgeable customer IDs using cursor/keyset pagination.
+   * Tracks the last seen customer ID and passes it as the cursor for each subsequent page.
+   * This is stable under concurrent deletions (unlike offset-based pagination).
    */
   private List<Integer> fetchAllPurgeableIds() {
+    long startMs = System.currentTimeMillis();
+    logger.info("fetchAllPurgeableIds started");
+
     List<Integer> allIds = new ArrayList<>();
-    long offset = 0;
+    int lastSeenId = 0;
 
     while (true) {
-      List<Integer> page = fetchPurgeablePage(offset, PAGE_SIZE);
+      List<Integer> page = fetchPurgeablePage(lastSeenId, PAGE_SIZE);
       allIds.addAll(page);
       if (page.size() < PAGE_SIZE) {
         break;
       }
-      offset += PAGE_SIZE;
+      lastSeenId = page.get(page.size() - 1);
     }
 
+    logger.info("fetchAllPurgeableIds finished in {}ms, found {} IDs",
+      System.currentTimeMillis() - startMs, allIds.size());
     return allIds;
   }
 
-  private List<Integer> fetchPurgeablePage(long offset, int pageSize) {
+  /**
+   * Fetches a single page of purgeable customer IDs using cursor-based pagination.
+   *
+   * @param afterId  cursor: return only customers with id greater than this value
+   * @param pageSize maximum number of IDs to return
+   */
+  private List<Integer> fetchPurgeablePage(int afterId, int pageSize) {
     String url = UriComponentsBuilder
         .fromUriString(applicationProperties.getPurgeableCustomersUrl())
         .queryParam("pageSize", pageSize)
-        .queryParam("offset", offset)
+        .queryParam("afterId", afterId)
         .toUriString();
 
     List<Integer> result = restTemplate.exchange(

--- a/backend/scheduler-service/src/test/java/service/CustomerPurgeServiceSpec.java
+++ b/backend/scheduler-service/src/test/java/service/CustomerPurgeServiceSpec.java
@@ -127,9 +127,9 @@ public class CustomerPurgeServiceSpec {
         });
 
         it("should continue processing remaining batches when one batch fails", () -> {
-          // 3 IDs → 3 batches of 1 each (use a tiny list so each is its own batch via the split logic)
-          // We provide 110 IDs so we get at least 3 batches (50+50+10), the middle one fails
-          List<Integer> ids = IntStream.rangeClosed(1, 110).boxed().toList();
+          // 600 IDs → 12 batches of 50. Batch 7 fails.
+          // Failure rate after batch 7: 50/350 ≈ 14% < 20% → no abort, all 12 batches run.
+          List<Integer> ids = IntStream.rangeClosed(1, 600).boxed().toList();
           mockPurgeablePage(ids);
 
           when(restTemplate.exchange(
@@ -138,14 +138,51 @@ public class CustomerPurgeServiceSpec {
             any(HttpEntity.class),
             eq(Integer.class)
           ))
-            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))        // batch 1 — ok
-            .thenThrow(new RestClientException("connection error"))      // batch 2 — fails
-            .thenReturn(new ResponseEntity<>(10, HttpStatus.OK));        // batch 3 — ok
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 1
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 2
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 3
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 4
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 5
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 6
+            .thenThrow(new RestClientException("connection error"))    // batch 7 — fails
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 8
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 9
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 10
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))       // batch 11
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK));      // batch 12
 
           purgeService.purgeObsoleteCustomers();
 
-          // All 3 batches must have been attempted despite the failure in batch 2
-          verify(restTemplate, times(3)).exchange(
+          // All 12 batches must have been attempted — failure rate stays below 20%
+          verify(restTemplate, times(12)).exchange(
+            eq(PURGE_CUSTOMERS_URL),
+            eq(HttpMethod.DELETE),
+            any(HttpEntity.class),
+            eq(Integer.class)
+          );
+        });
+
+        it("should abort processing when failure rate exceeds 20 percent threshold", () -> {
+          // 150 IDs → 3 batches of 50.
+          // Batch 1 succeeds (50 deleted), batch 2 fails.
+          // After batch 2: failedCount=50, total=100 → 50% >= 20% → ABORT; batch 3 never runs.
+          List<Integer> ids = IntStream.rangeClosed(1, 150).boxed().toList();
+          mockPurgeablePage(ids);
+
+          when(restTemplate.exchange(
+            eq(PURGE_CUSTOMERS_URL),
+            eq(HttpMethod.DELETE),
+            any(HttpEntity.class),
+            eq(Integer.class)
+          ))
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK))      // batch 1 — ok
+            .thenThrow(new RestClientException("network error"))            // batch 2 — fails → abort
+            .thenReturn(new ResponseEntity<>(50, HttpStatus.OK));     // batch 3 — must NOT be reached
+
+          purgeService.purgeObsoleteCustomers();
+
+          // Only 2 batches attempted; batch 3 was never called
+          verify(restTemplate, times(2)).exchange(
             eq(PURGE_CUSTOMERS_URL),
             eq(HttpMethod.DELETE),
             any(HttpEntity.class),


### PR DESCRIPTION
- ALLU-219: tarkistetaan SAP-sähköpostilähetyksen yhteydessä deaktivoitujen asiakkaiden relaatiot
- ALLU-207: lisätty indexejä parantamaan tietokantakyselyiden tehokkuutta
- ALLU-207: muutettu customer_archive-taulun customer_id-kenttä uniikiksi
- ALLU-207: parannettu asiakkaiden ajastettuun pysyvään poistoon liittyvää logiikkaa, lokitusta ja lisätty myös sinne relaatiotarkistukset liittyen deaktivoituihin asiakkaisiin

https://helsinkisolutionoffice.atlassian.net/browse/ALLU-219
https://helsinkisolutionoffice.atlassian.net/browse/ALLU-207